### PR TITLE
Fix hero logo overlapping text on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -151,4 +151,9 @@ h3 {
     flex-direction: column;
     gap: 0.5rem;
   }
+  .hero-logo {
+    top: 0.5rem;
+    left: 0.5rem;
+    width: 100px;
+  }
 }


### PR DESCRIPTION
## Summary
- adjust `.hero-logo` on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68614f07f7d083238a522df916adf5c9