### PR TITLE
Refactor services section with responsive Tailwind cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>R&D Nordic</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -30,54 +31,73 @@
     </section>
 
     <section id="services" class="services container">
-        <h2>What We Do</h2>
-        <div class="service-cards">
-            <article class="service-card">
-                <img src="images/project management.JPG" alt="Project management illustration">
-                <h3>Project Management</h3>
-                <ul>
+        <h2 class="text-3xl font-semibold text-[#005b96]">What We Do</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6">
+            <a href="#contact" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition group">
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Project Management</h3>
+                <p class="text-gray-700 mb-4">We plan and drive projects from concept to delivery with clarity and agility.</p>
+                <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
                     <li>Planning & execution</li>
                     <li>Agile methodologies</li>
                     <li>Risk management</li>
                 </ul>
-            </article>
-            <article class="service-card">
-                <img src="images/gdpr.jpg" alt="Data privacy concept">
-                <h3>Data Privacy & GDPR</h3>
-                <ul>
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                </span>
+            </a>
+            <a href="#contact" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition group">
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Data Privacy &amp; GDPR</h3>
+                <p class="text-gray-700 mb-4">We safeguard data handling and align operations with EU privacy regulations.</p>
+                <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
                     <li>Compliance assessments</li>
                     <li>Privacy policies</li>
                     <li>Security best practices</li>
                 </ul>
-            </article>
-            <article class="service-card">
-                <img src="images/AI.png" alt="Artificial intelligence">
-                <h3>AI Integration & Ethics</h3>
-                <ul>
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                </span>
+            </a>
+            <a href="#contact" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition group">
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">AI Integration &amp; Ethics</h3>
+                <p class="text-gray-700 mb-4">We design responsible AI approaches that accelerate workflows without compromising trust.</p>
+                <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
                     <li>Automation strategies</li>
                     <li>Ethical guidelines</li>
                     <li>Custom AI solutions</li>
                 </ul>
-            </article>
-            <article class="service-card">
-                <img src="images/grant funding.png" alt="Grant funding">
-                <h3>Grant Funding</h3>
-                <ul>
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                </span>
+            </a>
+            <a href="#contact" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition group">
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Grant Funding</h3>
+                <p class="text-gray-700 mb-4">We identify funding opportunities and craft proposals that secure the resources you need.</p>
+                <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
                     <li>Opportunity scanning</li>
                     <li>Application support</li>
                     <li>Budget planning</li>
                 </ul>
-            </article>
-            <article class="service-card">
-                <img src="images/gapmap(1).jpg" alt="Research strategy">
-                <h3>Research Strategy</h3>
-                <ul>
-                    <li>Roadmap development</li>
-                    <li>Collaboration advice</li>
-                    <li>Innovation projects</li>
-                </ul>
-            </article>
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                </span>
+            </a>
         </div>
+        <details class="mt-8 text-left">
+            <summary class="cursor-pointer text-[#005b96] font-semibold">More specialties</summary>
+            <ul class="mt-4 list-disc pl-5 text-gray-700 space-y-1">
+                <li><span class="font-semibold">Research Strategy:</span> roadmap development, collaboration advice, innovation projects.</li>
+                <li><span class="font-semibold">Workshops &amp; Training:</span> tailored sessions to upskill teams in new methods.</li>
+                <li><span class="font-semibold">Process Optimization:</span> efficiency audits and continuous improvement frameworks.</li>
+            </ul>
+        </details>
     </section>
 
 <!-- Why Us Section -->

--- a/style.css
+++ b/style.css
@@ -112,28 +112,6 @@ h3 {
   text-align: center;
 }
 
-.service-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
-  margin-top: 1rem;
-}
-
-.service-card {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  padding: 1.5rem;
-}
-
-.service-card img {
-  width: 100%;
-  height: 150px;
-  object-fit: cover;
-  border-radius: 4px;
-  margin-bottom: 1rem;
-}
-
 .why-us-section {
   background: #fff;
   padding: 2rem 0;


### PR DESCRIPTION
## Summary
- load Tailwind CSS from CDN
- replace five static service tiles with a responsive four-card grid including summaries, bullet deliverables and chevron links
- add expandable "More specialties" details section and remove legacy service tile styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6c64c8b483239ae1428619239a20