### PR TITLE
Add service pages with SEO metadata

### DIFF
--- a/services/ai-ethics.html
+++ b/services/ai-ethics.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Ethics &amp; Integration | R&D Nordic</title>
+  <meta name="description" content="Responsible AI integration with ethical governance and practical deployment.">
+  <link rel="canonical" href="https://rdnordic.com/services/ai-ethics.html">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar container">
+      <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+      <ul class="nav-links">
+        <li><a href="../index.html#hero">Home</a></li>
+        <li><a href="../index.html#services">What We Do</a></li>
+        <li><a href="../index.html#why-us">Why Us</a></li>
+        <li><a href="../index.html#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main class="container">
+    <h1>AI Ethics &amp; Integration</h1>
+    <section>
+      <h2>Problem</h2>
+      <p>Teams want the benefits of AI but face uncertainty around risk, bias and accountability.</p>
+    </section>
+    <section>
+      <h2>Approach</h2>
+      <p>We evaluate use cases, assess impacts and set guardrails so automation stays transparent and fair.</p>
+    </section>
+    <section>
+      <h2>Deliverables</h2>
+      <ul>
+        <li>AI readiness workshops</li>
+        <li>Ethical guidelines and governance frameworks</li>
+        <li>Prototype or integration support</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Outcomes</h2>
+      <p>Faster workflows, informed oversight and stakeholder confidence in responsible AI.</p>
+    </section>
+    <section>
+      <h2>Call to Action</h2>
+      <p>Build AI the right way – <a href="mailto:rdnordic@proton.me">contact us</a>.</p>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/services/grant-funding.html
+++ b/services/grant-funding.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Grant Funding | R&D Nordic</title>
+  <meta name="description" content="Strategic guidance to identify and secure research funding.">
+  <link rel="canonical" href="https://rdnordic.com/services/grant-funding.html">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar container">
+      <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+      <ul class="nav-links">
+        <li><a href="../index.html#hero">Home</a></li>
+        <li><a href="../index.html#services">What We Do</a></li>
+        <li><a href="../index.html#why-us">Why Us</a></li>
+        <li><a href="../index.html#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main class="container">
+    <h1>Grant Funding</h1>
+    <section>
+      <h2>Problem</h2>
+      <p>Finding the right call and crafting a competitive application consumes time and resources.</p>
+    </section>
+    <section>
+      <h2>Approach</h2>
+      <p>We scan opportunities, shape concepts and align budgets with funder expectations.</p>
+    </section>
+    <section>
+      <h2>Deliverables</h2>
+      <ul>
+        <li>Funding landscape reports</li>
+        <li>Proposal drafting and reviews</li>
+        <li>Impact and budget plans</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Outcomes</h2>
+      <p>Higher success rates and funding that enables your innovation.</p>
+    </section>
+    <section>
+      <h2>Call to Action</h2>
+      <p>Secure the resources you need – <a href="mailto:rdnordic@proton.me">email us</a> to get started.</p>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/services/privacy-gdpr.html
+++ b/services/privacy-gdpr.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy &amp; GDPR | R&D Nordic</title>
+  <meta name="description" content="Practical GDPR compliance and data privacy advisory services.">
+  <link rel="canonical" href="https://rdnordic.com/services/privacy-gdpr.html">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar container">
+      <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+      <ul class="nav-links">
+        <li><a href="../index.html#hero">Home</a></li>
+        <li><a href="../index.html#services">What We Do</a></li>
+        <li><a href="../index.html#why-us">Why Us</a></li>
+        <li><a href="../index.html#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main class="container">
+    <h1>Privacy &amp; GDPR</h1>
+    <section>
+      <h2>Problem</h2>
+      <p>Organisations must handle personal data responsibly while navigating evolving regulations.</p>
+    </section>
+    <section>
+      <h2>Approach</h2>
+      <p>We map data flows, craft policies and train teams to embed privacy by design.</p>
+    </section>
+    <section>
+      <h2>Deliverables</h2>
+      <ul>
+        <li>Compliance gap analysis</li>
+        <li>Privacy policies and DPIAs</li>
+        <li>Security and retention guidelines</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Outcomes</h2>
+      <p>Reduced regulatory risk and demonstrable trust with customers and partners.</p>
+    </section>
+    <section>
+      <h2>Call to Action</h2>
+      <p>Protect your data practices – <a href="mailto:rdnordic@proton.me">email us</a> for support.</p>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/services/project-management.html
+++ b/services/project-management.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Project Management | R&D Nordic</title>
+  <meta name="description" content="Agile project management consulting from planning to delivery.">
+  <link rel="canonical" href="https://rdnordic.com/services/project-management.html">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar container">
+      <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+      <ul class="nav-links">
+        <li><a href="../index.html#hero">Home</a></li>
+        <li><a href="../index.html#services">What We Do</a></li>
+        <li><a href="../index.html#why-us">Why Us</a></li>
+        <li><a href="../index.html#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main class="container">
+    <h1>Project Management</h1>
+    <section>
+      <h2>Problem</h2>
+      <p>Innovation projects often face shifting priorities, limited resources and unclear communication, leading to delays and frustration.</p>
+    </section>
+    <section>
+      <h2>Approach</h2>
+      <p>We combine structured planning with agile execution, setting milestones, facilitating collaboration and tracking risks.</p>
+    </section>
+    <section>
+      <h2>Deliverables</h2>
+      <ul>
+        <li>Project plan and timeline</li>
+        <li>Communication routines</li>
+        <li>Risk and issue registers</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Outcomes</h2>
+      <p>Aligned teams, transparent progress and projects delivered on time and on budget.</p>
+    </section>
+    <section>
+      <h2>Call to Action</h2>
+      <p>Ready to move your project forward? <a href="mailto:rdnordic@proton.me">Email us</a>.</p>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add project management, privacy/GDPR, AI ethics, and grant funding service pages
- include canonical links and meta descriptions for SEO
- structure content into problem, approach, deliverables, outcomes, and call to action sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad707ebbd08323b94ad2c5360d7c23