### PR TITLE
Left align body text and limit hero centering

### DIFF
--- a/style.css
+++ b/style.css
@@ -73,7 +73,7 @@ h3 {
   display: flex;
   align-items: center;
   justify-content: center;
-  text-align: center;
+  text-align: left;
   color: #fff;
 }
 
@@ -92,6 +92,7 @@ h3 {
   font-size: 2.5rem;
   margin-bottom: 0.5rem;
   font-weight: 300;
+  text-align: center;
 }
 
 .hero-text {
@@ -109,13 +110,13 @@ h3 {
 
 .services {
   padding: 2rem 0;
-  text-align: center;
+  text-align: left;
 }
 
 .why-us-section {
   background: #fff;
   padding: 2rem 0;
-  text-align: center;
+  text-align: left;
 }
 
 .why-us-section ul {
@@ -127,11 +128,11 @@ h3 {
 
 .contact {
   padding: 2rem 0;
-  text-align: center;
+  text-align: left;
 }
 
 .site-footer {
-  text-align: center;
+  text-align: left;
   padding: 1rem 0;
   font-size: 0.9rem;
 }


### PR DESCRIPTION
## Summary
- Left-align body text across sections and footer
- Keep hero heading centered while keeping hero paragraph left aligned

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8a128d9883239bf2e1cf9b8cea2d