### PR TITLE
Add dedicated service pages and link from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <section id="services" class="services container">
         <h2 class="text-3xl font-semibold text-[#005b96]">What We Do</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6 items-stretch">
-            <a href="#contact" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+            <a href="/services/project-management.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
                 <h3 class="text-xl font-semibold text-[#005b96] mb-2">Project Management</h3>
                 <p class="text-gray-700 mb-4">We plan and drive projects from concept to delivery with clarity and agility.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
@@ -48,7 +48,7 @@
                     </svg>
                 </span>
             </a>
-            <a href="#contact" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+            <a href="/services/privacy-gdpr.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
                 <h3 class="text-xl font-semibold text-[#005b96] mb-2">Data Privacy &amp; GDPR</h3>
                 <p class="text-gray-700 mb-4">We safeguard data handling and align operations with EU privacy regulations.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
@@ -62,7 +62,7 @@
                     </svg>
                 </span>
             </a>
-            <a href="#contact" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+            <a href="/services/ai-ethics.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
                 <h3 class="text-xl font-semibold text-[#005b96] mb-2">AI Integration &amp; Ethics</h3>
                 <p class="text-gray-700 mb-4">We design responsible AI approaches that accelerate workflows without compromising trust.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
@@ -76,7 +76,7 @@
                     </svg>
                 </span>
             </a>
-            <a href="#contact" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+            <a href="/services/grant-funding.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
                 <h3 class="text-xl font-semibold text-[#005b96] mb-2">Grant Funding</h3>
                 <p class="text-gray-700 mb-4">We identify funding opportunities and craft proposals that secure the resources you need.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">

--- a/services/ai-ethics.html
+++ b/services/ai-ethics.html
@@ -1,55 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI Ethics &amp; Integration | R&D Nordic</title>
-  <meta name="description" content="Responsible AI integration with ethical governance and practical deployment.">
-  <link rel="canonical" href="https://rdnordic.com/services/ai-ethics.html">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../style.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Ethics &amp; Integration | R&amp;D Nordic</title>
+    <meta name="description" content="Ethical AI strategies that balance innovation with accountability and transparency.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="site-header">
-    <nav class="navbar container">
-      <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
-      <ul class="nav-links">
-        <li><a href="../index.html#hero">Home</a></li>
-        <li><a href="../index.html#services">What We Do</a></li>
-        <li><a href="../index.html#why-us">Why Us</a></li>
-        <li><a href="../index.html#contact">Contact</a></li>
-      </ul>
-    </nav>
-  </header>
-  <main class="container">
-    <h1>AI Ethics &amp; Integration</h1>
-    <section>
-      <h2>Problem</h2>
-      <p>Teams want the benefits of AI but face uncertainty around risk, bias and accountability.</p>
-    </section>
-    <section>
-      <h2>Approach</h2>
-      <p>We evaluate use cases, assess impacts and set guardrails so automation stays transparent and fair.</p>
-    </section>
-    <section>
-      <h2>Deliverables</h2>
-      <ul>
-        <li>AI readiness workshops</li>
-        <li>Ethical guidelines and governance frameworks</li>
-        <li>Prototype or integration support</li>
-      </ul>
-    </section>
-    <section>
-      <h2>Outcomes</h2>
-      <p>Faster workflows, informed oversight and stakeholder confidence in responsible AI.</p>
-    </section>
-    <section>
-      <h2>Call to Action</h2>
-      <p>Build AI the right way – <a href="mailto:rdnordic@proton.me">contact us</a>.</p>
-    </section>
-  </main>
-  <footer class="site-footer">
-    <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
-  </footer>
+    <header class="site-header">
+        <nav class="navbar container">
+            <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+            <ul class="nav-links">
+                <li><a href="../index.html#hero">Home</a></li>
+                <li><a href="../index.html#services">What We Do</a></li>
+                <li><a href="../index.html#why-us">Why Us</a></li>
+                <li><a href="../index.html#cases">Cases</a></li>
+                <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">AI Ethics &amp; Integration</h1>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
+            <p class="text-gray-700">Organisations want the productivity of AI but fear bias, opacity and regulatory uncertainty.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Our approach</h2>
+            <p class="text-gray-700">We evaluate use cases, assess impacts and embed governance so automation remains transparent and fair.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typical deliverables</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>AI readiness and risk workshops</li>
+                <li>Ethical guidelines and governance frameworks</li>
+                <li>Bias and transparency assessments</li>
+                <li>Prototype or integration support</li>
+            </ul>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Outcomes</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Responsible, explainable AI solutions</li>
+                <li>Reduced ethical and compliance risk</li>
+                <li>Confidence from stakeholders and regulators</li>
+            </ul>
+        </section>
+        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
+    </footer>
 </body>
 </html>
+

--- a/services/grant-funding.html
+++ b/services/grant-funding.html
@@ -1,55 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Grant Funding | R&D Nordic</title>
-  <meta name="description" content="Strategic guidance to identify and secure research funding.">
-  <link rel="canonical" href="https://rdnordic.com/services/grant-funding.html">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../style.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Grant Funding | R&amp;D Nordic</title>
+    <meta name="description" content="Expert support to find calls, craft proposals and secure research funding.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="site-header">
-    <nav class="navbar container">
-      <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
-      <ul class="nav-links">
-        <li><a href="../index.html#hero">Home</a></li>
-        <li><a href="../index.html#services">What We Do</a></li>
-        <li><a href="../index.html#why-us">Why Us</a></li>
-        <li><a href="../index.html#contact">Contact</a></li>
-      </ul>
-    </nav>
-  </header>
-  <main class="container">
-    <h1>Grant Funding</h1>
-    <section>
-      <h2>Problem</h2>
-      <p>Finding the right call and crafting a competitive application consumes time and resources.</p>
-    </section>
-    <section>
-      <h2>Approach</h2>
-      <p>We scan opportunities, shape concepts and align budgets with funder expectations.</p>
-    </section>
-    <section>
-      <h2>Deliverables</h2>
-      <ul>
-        <li>Funding landscape reports</li>
-        <li>Proposal drafting and reviews</li>
-        <li>Impact and budget plans</li>
-      </ul>
-    </section>
-    <section>
-      <h2>Outcomes</h2>
-      <p>Higher success rates and funding that enables your innovation.</p>
-    </section>
-    <section>
-      <h2>Call to Action</h2>
-      <p>Secure the resources you need – <a href="mailto:rdnordic@proton.me">email us</a> to get started.</p>
-    </section>
-  </main>
-  <footer class="site-footer">
-    <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
-  </footer>
+    <header class="site-header">
+        <nav class="navbar container">
+            <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+            <ul class="nav-links">
+                <li><a href="../index.html#hero">Home</a></li>
+                <li><a href="../index.html#services">What We Do</a></li>
+                <li><a href="../index.html#why-us">Why Us</a></li>
+                <li><a href="../index.html#cases">Cases</a></li>
+                <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Grant Funding</h1>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
+            <p class="text-gray-700">Identifying the right programme and preparing a competitive proposal is time consuming and complex.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Our approach</h2>
+            <p class="text-gray-700">We scan calls, shape concepts and guide submissions to match funder expectations.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typical deliverables</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Funding opportunity scans</li>
+                <li>Concept notes and proposal drafts</li>
+                <li>Budget and impact narratives</li>
+                <li>Submission management</li>
+            </ul>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Outcomes</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Higher win rates for grants</li>
+                <li>Clear, funder-aligned project plans</li>
+                <li>Resources secured to advance innovation</li>
+            </ul>
+        </section>
+        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
+    </footer>
 </body>
 </html>
+

--- a/services/privacy-gdpr.html
+++ b/services/privacy-gdpr.html
@@ -1,55 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Privacy &amp; GDPR | R&D Nordic</title>
-  <meta name="description" content="Practical GDPR compliance and data privacy advisory services.">
-  <link rel="canonical" href="https://rdnordic.com/services/privacy-gdpr.html">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../style.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Privacy &amp; GDPR | R&amp;D Nordic</title>
+    <meta name="description" content="Hands-on GDPR guidance to map data, mitigate risk and build trusted processes.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="site-header">
-    <nav class="navbar container">
-      <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
-      <ul class="nav-links">
-        <li><a href="../index.html#hero">Home</a></li>
-        <li><a href="../index.html#services">What We Do</a></li>
-        <li><a href="../index.html#why-us">Why Us</a></li>
-        <li><a href="../index.html#contact">Contact</a></li>
-      </ul>
-    </nav>
-  </header>
-  <main class="container">
-    <h1>Privacy &amp; GDPR</h1>
-    <section>
-      <h2>Problem</h2>
-      <p>Organisations must handle personal data responsibly while navigating evolving regulations.</p>
-    </section>
-    <section>
-      <h2>Approach</h2>
-      <p>We map data flows, craft policies and train teams to embed privacy by design.</p>
-    </section>
-    <section>
-      <h2>Deliverables</h2>
-      <ul>
-        <li>Compliance gap analysis</li>
-        <li>Privacy policies and DPIAs</li>
-        <li>Security and retention guidelines</li>
-      </ul>
-    </section>
-    <section>
-      <h2>Outcomes</h2>
-      <p>Reduced regulatory risk and demonstrable trust with customers and partners.</p>
-    </section>
-    <section>
-      <h2>Call to Action</h2>
-      <p>Protect your data practices – <a href="mailto:rdnordic@proton.me">email us</a> for support.</p>
-    </section>
-  </main>
-  <footer class="site-footer">
-    <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
-  </footer>
+    <header class="site-header">
+        <nav class="navbar container">
+            <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+            <ul class="nav-links">
+                <li><a href="../index.html#hero">Home</a></li>
+                <li><a href="../index.html#services">What We Do</a></li>
+                <li><a href="../index.html#why-us">Why Us</a></li>
+                <li><a href="../index.html#cases">Cases</a></li>
+                <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Data Privacy &amp; GDPR</h1>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
+            <p class="text-gray-700">Many organisations collect personal data without clear oversight, creating compliance gaps and exposure to fines.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Our approach</h2>
+            <p class="text-gray-700">We map data flows, assess risks and implement governance so privacy obligations are met across the board.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typical deliverables</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Data processing inventories</li>
+                <li>Data protection impact assessments</li>
+                <li>Privacy policies and consent language</li>
+                <li>Staff training and awareness sessions</li>
+            </ul>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Outcomes</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Reduced breach and penalty risk</li>
+                <li>Demonstrated regulatory compliance</li>
+                <li>Greater trust from customers and partners</li>
+            </ul>
+        </section>
+        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
+    </footer>
 </body>
 </html>
+

--- a/services/project-management.html
+++ b/services/project-management.html
@@ -1,55 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Project Management | R&D Nordic</title>
-  <meta name="description" content="Agile project management consulting from planning to delivery.">
-  <link rel="canonical" href="https://rdnordic.com/services/project-management.html">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="../style.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Management | R&amp;D Nordic</title>
+    <meta name="description" content="Structured project leadership that keeps milestones, risks and teams on track.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../style.css">
 </head>
 <body>
-  <header class="site-header">
-    <nav class="navbar container">
-      <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
-      <ul class="nav-links">
-        <li><a href="../index.html#hero">Home</a></li>
-        <li><a href="../index.html#services">What We Do</a></li>
-        <li><a href="../index.html#why-us">Why Us</a></li>
-        <li><a href="../index.html#contact">Contact</a></li>
-      </ul>
-    </nav>
-  </header>
-  <main class="container">
-    <h1>Project Management</h1>
-    <section>
-      <h2>Problem</h2>
-      <p>Innovation projects often face shifting priorities, limited resources and unclear communication, leading to delays and frustration.</p>
-    </section>
-    <section>
-      <h2>Approach</h2>
-      <p>We combine structured planning with agile execution, setting milestones, facilitating collaboration and tracking risks.</p>
-    </section>
-    <section>
-      <h2>Deliverables</h2>
-      <ul>
-        <li>Project plan and timeline</li>
-        <li>Communication routines</li>
-        <li>Risk and issue registers</li>
-      </ul>
-    </section>
-    <section>
-      <h2>Outcomes</h2>
-      <p>Aligned teams, transparent progress and projects delivered on time and on budget.</p>
-    </section>
-    <section>
-      <h2>Call to Action</h2>
-      <p>Ready to move your project forward? <a href="mailto:rdnordic@proton.me">Email us</a>.</p>
-    </section>
-  </main>
-  <footer class="site-footer">
-    <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
-  </footer>
+    <header class="site-header">
+        <nav class="navbar container">
+            <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+            <ul class="nav-links">
+                <li><a href="../index.html#hero">Home</a></li>
+                <li><a href="../index.html#services">What We Do</a></li>
+                <li><a href="../index.html#why-us">Why Us</a></li>
+                <li><a href="../index.html#cases">Cases</a></li>
+                <li><a href="../index.html#contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Project Management</h1>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
+            <p class="text-gray-700">Teams struggle with shifting priorities, limited resources and unclear roles that derail timelines.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Our approach</h2>
+            <p class="text-gray-700">We blend structured planning with agile routines to establish clarity, manage risks and keep stakeholders aligned.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typical deliverables</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Project charters and roadmaps</li>
+                <li>Sprint schedules and task boards</li>
+                <li>Risk and issue registers</li>
+                <li>Stakeholder communication plans</li>
+            </ul>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Outcomes</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Clear milestones and ownership</li>
+                <li>Controlled risks and scope</li>
+                <li>Projects delivered on time</li>
+            </ul>
+        </section>
+        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved.</p>
+    </footer>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add four Tailwind-powered service pages for project management, privacy & GDPR, AI ethics, and grant funding, each with problem, approach, deliverables, outcomes, and meeting CTA
- update homepage service cards to point to the new service pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8f13cae8832397abf3f66a488588