### PR TITLE
Localize site to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                 </span>
             </a>
             <a href="/services/privacy-gdpr.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Data Privacy &amp; GDPR</h3>
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Privacy &amp; GDPR</h3>
                 <p class="text-gray-700 mb-4">We safeguard data handling and align operations with EU privacy regulations.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
                     <li>Compliance assessments</li>
@@ -158,29 +158,29 @@
             <input type="text" name="_honey" style="display:none">
             <input type="hidden" name="_captcha" value="false">
 
-            <label class="block text-sm">Navn</label>
+            <label class="block text-sm">Name</label>
             <input name="name" required class="w-full rounded-xl bg-white/5 border border-white/10 px-4 py-3">
 
-            <label class="block text-sm mt-2">E-post</label>
+            <label class="block text-sm mt-2">Email</label>
             <input type="email" name="email" required class="w-full rounded-xl bg-white/5 border border-white/10 px-4 py-3">
 
-            <label class="block text-sm mt-2">Melding</label>
+            <label class="block text-sm mt-2">Message</label>
             <textarea name="message" rows="5" required class="w-full rounded-xl bg-white/5 border border-white/10 px-4 py-3"></textarea>
 
             <label class="flex items-start gap-2 text-sm mt-2">
               <input type="checkbox" name="consent" required class="mt-1">
-              <span>Jeg samtykker til at R&amp;D Nordic behandler mine opplysninger som beskrevet i
-                <a href="/privacy.html" class="underline">Personvernerklæringen</a>.
+              <span>I consent to R&amp;D Nordic processing my data as described in the
+                <a href="/privacy.html" class="underline">Privacy Notice</a>.
               </span>
             </label>
 
             <button type="submit" class="rounded-xl bg-white text-slate-900 px-5 py-3 font-semibold w-full">Send</button>
         </form>
-        <p class="mt-4">Eller <a href="mailto:rdnordic@proton.me" class="text-[#005b96] underline">send oss en e-post</a>.</p>
+        <p class="mt-4">Or <a href="mailto:rdnordic@proton.me" class="text-[#005b96] underline">send us an email</a>.</p>
     </section>
 
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Personvern</a> | <a href="#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="#contact">Contact</a></p>
     </footer>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Personvern | R&D Nordic</title>
+    <title>Privacy Notice | R&D Nordic</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
@@ -22,62 +22,62 @@
         </nav>
     </header>
     <main class="container py-8">
-        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Personvernerklæring</h1>
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Privacy Notice</h1>
         <nav class="mb-6">
             <ul class="list-disc pl-5 space-y-1">
-                <li><a href="#dataansvarlig" class="text-[#005b96] underline">Dataansvarlig</a></li>
-                <li><a href="#formaal" class="text-[#005b96] underline">Formål med behandling</a></li>
-                <li><a href="#grunnlag" class="text-[#005b96] underline">Behandlingsgrunnlag</a></li>
-                <li><a href="#lagring" class="text-[#005b96] underline">Lagringstid</a></li>
-                <li><a href="#rettigheter" class="text-[#005b96] underline">Dine rettigheter</a></li>
-                <li><a href="#databehandlere" class="text-[#005b96] underline">Databehandlere</a></li>
-                <li><a href="#kapsler" class="text-[#005b96] underline">Informasjonskapsler</a></li>
-                <li><a href="#kontakt" class="text-[#005b96] underline">Kontaktpunkt for personvern</a></li>
+                <li><a href="#data-controller" class="text-[#005b96] underline">Data Controller</a></li>
+                <li><a href="#purpose" class="text-[#005b96] underline">Purpose of Processing</a></li>
+                <li><a href="#legal-basis" class="text-[#005b96] underline">Legal Basis</a></li>
+                <li><a href="#retention" class="text-[#005b96] underline">Retention Period</a></li>
+                <li><a href="#rights" class="text-[#005b96] underline">Your Rights</a></li>
+                <li><a href="#processors" class="text-[#005b96] underline">Processors</a></li>
+                <li><a href="#cookies" class="text-[#005b96] underline">Cookies</a></li>
+                <li><a href="#privacy-contact" class="text-[#005b96] underline">Privacy Contact</a></li>
             </ul>
         </nav>
-        <section id="dataansvarlig" class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Dataansvarlig</h2>
-            <p>R&amp;D Nordic AS er dataansvarlig for behandlingen av personopplysninger. Kontakt oss på <a href="mailto:rdnordic@proton.me" class="text-[#005b96] underline">rdnordic@proton.me</a>.</p>
+        <section id="data-controller" class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Data Controller</h2>
+            <p>R&amp;D Nordic AS is the data controller for the processing of personal data. Contact us at <a href="mailto:rdnordic@proton.me" class="text-[#005b96] underline">rdnordic@proton.me</a>.</p>
         </section>
-        <section id="formaal" class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Formål med behandling</h2>
+        <section id="purpose" class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Purpose of Processing</h2>
             <ul class="list-disc pl-5 space-y-1">
-                <li>Henvendelser via kontaktskjema</li>
-                <li>Enkel webanalyse uten persondata</li>
-                <li>Kundeadministrasjon</li>
+                <li>Enquiries via contact form</li>
+                <li>Basic web analytics without personal data</li>
+                <li>Customer administration</li>
             </ul>
         </section>
-        <section id="grunnlag" class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Behandlingsgrunnlag</h2>
-            <p>Behandlingen skjer i henhold til GDPR art. 6(1)(b) og art. 6(1)(f).</p>
+        <section id="legal-basis" class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Legal Basis</h2>
+            <p>Processing is carried out pursuant to GDPR art. 6(1)(b) and art. 6(1)(f).</p>
         </section>
-        <section id="lagring" class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Lagringstid</h2>
-            <p>Henvendelser lagres i opptil 12 måneder. Vi gjennomfører en årlig gjennomgang og sletter meldinger som ikke lenger er nødvendige.</p>
+        <section id="retention" class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Retention Period</h2>
+            <p>Enquiries are stored for up to 12 months. We conduct an annual review and delete messages that are no longer needed.</p>
         </section>
-        <section id="rettigheter" class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Dine rettigheter</h2>
-            <p>Du har rett til innsyn, retting, sletting, begrensning, protest og til å klage til Datatilsynet.</p>
+        <section id="rights" class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Your Rights</h2>
+            <p>You have the right to access, rectification, erasure, restriction, objection and to lodge a complaint with the supervisory authority.</p>
         </section>
-        <section id="databehandlere" class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Databehandlere</h2>
-            <p>Vi bruker utvalgte leverandører for å drifte tjenestene våre:</p>
+        <section id="processors" class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Processors</h2>
+            <p>We use selected suppliers to operate our services:</p>
             <ul class="list-disc pl-5 space-y-1">
-                <li><strong>Skjemaløsning/e-postleverandør</strong> – formidler skjemaer til vår innboks og lagrer dem kortvarig.</li>
-                <li><strong>Webhotell</strong> – nettsiden hostes hos en leverandør som lagrer nødvendige tekniske logger.</li>
+                <li><strong>Form solution/email provider</strong> – forwards forms to our inbox and stores them briefly.</li>
+                <li><strong>Web hosting</strong> – the website is hosted by a provider that stores necessary technical logs.</li>
             </ul>
         </section>
-        <section id="kapsler" class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Informasjonskapsler</h2>
-            <p>Vi bruker kun nødvendige informasjonskapsler. Det kan bli lagt til et banner ved behov i fremtiden.</p>
+        <section id="cookies" class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Cookies</h2>
+            <p>We use only necessary cookies. A banner may be added if needed in the future.</p>
         </section>
-        <section id="kontakt" class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Kontaktpunkt for personvern</h2>
-            <p>Har du spørsmål om personvern? Kontakt oss på <a href="mailto:rdnordic@proton.me" class="text-[#005b96] underline">rdnordic@proton.me</a>.</p>
+        <section id="privacy-contact" class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Privacy Contact</h2>
+            <p>Have questions about privacy? Contact us at <a href="mailto:rdnordic@proton.me" class="text-[#005b96] underline">rdnordic@proton.me</a>.</p>
         </section>
     </main>
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Personvern</a> | <a href="/index.html#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
     </footer>
 </body>
 </html>

--- a/services/ai-ethics.html
+++ b/services/ai-ethics.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI Ethics &amp; Integration | R&amp;D Nordic</title>
+    <title>AI Integration &amp; Ethics | R&amp;D Nordic</title>
     <meta name="description" content="Ethical AI strategies that balance innovation with accountability and transparency.">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -23,7 +23,7 @@
         </nav>
     </header>
     <main class="container py-8">
-        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">AI Ethics &amp; Integration</h1>
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">AI Integration &amp; Ethics</h1>
         <section class="mb-6">
             <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
             <p class="text-gray-700">Organisations want the productivity of AI but fear bias, opacity and regulatory uncertainty.</p>
@@ -52,7 +52,7 @@
         <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
     </main>
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Personvern</a> | <a href="/index.html#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
     </footer>
 </body>
 </html>

--- a/services/grant-funding.html
+++ b/services/grant-funding.html
@@ -52,7 +52,7 @@
         <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
     </main>
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Personvern</a> | <a href="/index.html#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
     </footer>
 </body>
 </html>

--- a/services/privacy-gdpr.html
+++ b/services/privacy-gdpr.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Data Privacy &amp; GDPR | R&amp;D Nordic</title>
+    <title>Privacy &amp; GDPR | R&amp;D Nordic</title>
     <meta name="description" content="Hands-on GDPR guidance to map data, mitigate risk and build trusted processes.">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
@@ -23,7 +23,7 @@
         </nav>
     </header>
     <main class="container py-8">
-        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Data Privacy &amp; GDPR</h1>
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Privacy &amp; GDPR</h1>
         <section class="mb-6">
             <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
             <p class="text-gray-700">Many organisations collect personal data without clear oversight, creating compliance gaps and exposure to fines.</p>
@@ -52,7 +52,7 @@
         <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
     </main>
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Personvern</a> | <a href="/index.html#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
     </footer>
 </body>
 </html>

--- a/services/project-management.html
+++ b/services/project-management.html
@@ -52,7 +52,7 @@
         <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
     </main>
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Personvern</a> | <a href="/index.html#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
     </footer>
 </body>
 </html>

--- a/thanks.html
+++ b/thanks.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Takk | R&amp;D Nordic</title>
+    <title>Thank You | R&amp;D Nordic</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
@@ -22,12 +22,12 @@
         </nav>
     </header>
     <main class="container py-20 text-center">
-        <h1 class="text-3xl font-semibold text-[#005b96] mb-4">Takk for henvendelsen</h1>
-        <p class="mb-6">Vi svarer innen 1–2 arbeidsdager.</p>
-        <a href="/" class="rounded-xl bg-white text-slate-900 px-5 py-3 font-semibold inline-block">Tilbake</a>
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-4">Thanks for your message</h1>
+        <p class="mb-6">We will respond within 1–2 business days.</p>
+        <a href="/" class="rounded-xl bg-white text-slate-900 px-5 py-3 font-semibold inline-block">Back</a>
     </main>
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Personvern</a> | <a href="/index.html#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- translate contact form labels, consent text, and footer links to English
- rename service pages and headings to English terms
- rewrite privacy notice and thank-you pages in English

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aec345f9f08323b75f4f7ce18cf783