### PR TITLE
Add Norwegian localized pages with language switcher

### DIFF
--- a/no/index.html
+++ b/no/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="no">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>R&D Nordic</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="style.css">
-    <link rel="alternate" hreflang="en" href="https://rdnordic.com/">
+    <link rel="stylesheet" href="../style.css">
     <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/">
+    <link rel="alternate" hreflang="en" href="https://rdnordic.com/">
     <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/">
 </head>
 <body>
@@ -16,35 +16,35 @@
         <nav class="navbar container">
             <a class="logo" href="#hero">R&D Nordic</a>
             <ul class="nav-links">
-                <li><a href="#hero">Home</a></li>
-                <li><a href="#services">What We Do</a></li>
-                <li><a href="#why-us">Why Us</a></li>
-                <li><a href="#cases">Cases</a></li>
-                <li><a href="#contact">Contact</a></li>
+                <li><a href="#hero">Hjem</a></li>
+                <li><a href="#services">Hva gjør vi</a></li>
+                <li><a href="#why-us">Hvorfor velge oss</a></li>
+                <li><a href="#cases">Erfaringer</a></li>
+                <li><a href="#contact">Kontakt</a></li>
             </ul>
             <span class="ml-4 text-sm">
-                <a href="/" aria-current="page" class="font-semibold">EN</a>
+                <a href="/">EN</a>
                 <span class="mx-1">|</span>
-                <a href="/no/">NO</a>
+                <a href="/no/" aria-current="page" class="font-semibold">NO</a>
             </span>
         </nav>
     </header>
 
     <section id="hero" class="hero">
-        <img src="images/northern lights.jpg" alt="Nordic landscape" class="hero-img">
-        <img src="images/rndnordiclogo.png" alt="R&D Nordic logo" class="hero-logo">
+        <img src="../images/northern lights.jpg" alt="Nordic landscape" class="hero-img">
+        <img src="../images/rndnordiclogo.png" alt="R&D Nordic logo" class="hero-logo">
         <div class="hero-text container max-w-3xl mx-auto text-center">
-            <h1>Future-Proof Consulting</h1>
-            <p>Project management, data privacy, AI integration and research funding guidance.</p>
+            <h1>Fremtidsrettet rådgivning</h1>
+            <p>Prosjektledelse, personvern, etikk, IPR, KI-integrasjon og forskningsfinansiering.</p>
         </div>
     </section>
 
     <section id="services" class="services container">
-        <h2 class="text-3xl font-semibold text-[#005b96]">What We Do</h2>
+        <h2 class="text-3xl font-semibold text-[#005b96]">Hva vi gjør</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6 items-stretch">
             <a href="/services/project-management.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Project Management</h3>
-                <p class="text-gray-700 mb-4">We plan and drive projects from concept to delivery with clarity and agility.</p>
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Prosjektledelse</h3>
+                <p class="text-gray-700 mb-4">Plan, leveranse og gevinstrealisering.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
                     <li>Planning & execution</li>
                     <li>Agile methodologies</li>
@@ -57,8 +57,8 @@
                 </span>
             </a>
             <a href="/services/privacy-gdpr.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Privacy &amp; GDPR</h3>
-                <p class="text-gray-700 mb-4">We safeguard data handling and align operations with EU privacy regulations.</p>
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Personvern og GDPR</h3>
+                <p class="text-gray-700 mb-4">DPIA, avtaler, dataminimering og opplæring.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
                     <li>Compliance assessments</li>
                     <li>Privacy policies</li>
@@ -71,8 +71,8 @@
                 </span>
             </a>
             <a href="/services/ai-ethics.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">AI Integration &amp; Ethics</h3>
-                <p class="text-gray-700 mb-4">We design responsible AI approaches that accelerate workflows without compromising trust.</p>
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">KI-integrasjon og etikk</h3>
+                <p class="text-gray-700 mb-4">Fra pilot til skala. AI Act-klar styring.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
                     <li>Automation strategies</li>
                     <li>Ethical guidelines</li>
@@ -85,8 +85,8 @@
                 </span>
             </a>
             <a href="/services/grant-funding.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Grant Funding</h3>
-                <p class="text-gray-700 mb-4">We identify funding opportunities and craft proposals that secure the resources you need.</p>
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Forskningsmidler</h3>
+                <p class="text-gray-700 mb-4">Strategi, konsortier og leveranseplaner.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
                     <li>Opportunity scanning</li>
                     <li>Application support</li>
@@ -100,11 +100,11 @@
             </a>
         </div>
         <details class="mt-8 text-left">
-            <summary class="cursor-pointer text-[#005b96] font-semibold">More specialties</summary>
+            <summary class="cursor-pointer text-[#005b96] font-semibold">Flere spesialiteter</summary>
             <ul class="mt-4 list-disc pl-5 text-gray-700 space-y-1">
-                <li><span class="font-semibold">Research Strategy:</span> roadmap development, collaboration advice, innovation projects.</li>
-                <li><span class="font-semibold">Workshops &amp; Training:</span> tailored sessions to upskill teams in new methods.</li>
-                <li><span class="font-semibold">Process Optimization:</span> efficiency audits and continuous improvement frameworks.</li>
+                <li>Forskningsstrategi og evalueringsrammer</li>
+                <li>Informasjonssikkerhet</li>
+                <li>Opplæring for ledere og ansatte</li>
             </ul>
         </details>
     </section>
@@ -112,19 +112,19 @@
 <!-- Why Choose Us Strip -->
 <section id="why-us" class="why-us-section">
   <div class="container">
-    <h2 class="text-3xl font-semibold text-[#005b96] text-center">Why Choose Us</h2>
+    <h2 class="text-3xl font-semibold text-[#005b96] text-center">Hvorfor velge oss</h2>
     <ul class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-6 list-none p-0">
       <li class="bg-white rounded-lg shadow-md p-6 text-center">
         <span class="text-4xl font-bold text-[#005b96]">50+</span>
-        <p class="mt-2 text-gray-700">DPIAs completed</p>
+        <p class="mt-2 text-gray-700">DPIA gjennomført</p>
       </li>
       <li class="bg-white rounded-lg shadow-md p-6 text-center">
         <span class="text-4xl font-bold text-[#005b96]">100&nbsp;MNOK</span>
-        <p class="mt-2 text-gray-700">quality-assured</p>
+        <p class="mt-2 text-gray-700">Søknader kvalitetssikret</p>
       </li>
       <li class="bg-white rounded-lg shadow-md p-6 text-center">
         <span class="text-4xl font-bold text-[#005b96]">25M&nbsp;EUR</span>
-        <p class="mt-2 text-gray-700">funding secured</p>
+        <p class="mt-2 text-gray-700">finansiering sikret</p>
       </li>
     </ul>
   </div>
@@ -132,31 +132,31 @@
 
 <!-- Cases Section -->
 <section id="cases" class="cases container">
-  <h2 class="text-2xl md:text-3xl font-semibold">Featured cases</h2>
+  <h2 class="text-2xl md:text-3xl font-semibold">Utvalgte caser</h2>
   <div class="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-6">
     <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-      <h3 class="text-xl font-semibold text-blue-700">AI training for public &amp; private sector</h3>
+      <h3 class="text-xl font-semibold text-blue-700">AI-opplæring for offentlig og privat sektor</h3>
       <p class="mt-3"><strong>Problem:</strong> Organisations unsure how to adopt AI responsibly.</p>
       <p class="mt-1"><strong>Action:</strong> Delivered training on AI, IPR, Ethics and Data Privacy with practical use cases.</p>
       <p class="mt-1"><strong>Effect:</strong> Teams adopted safe, effective workflows and reduced risk.</p>
     </article>
 
     <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-      <h3 class="text-xl font-semibold text-blue-700">AI &amp; IPR for creative industries</h3>
+      <h3 class="text-xl font-semibold text-blue-700">KI og IPR for kreative næringer</h3>
       <p class="mt-3"><strong>Problem:</strong> Arts partners concerned about rights and originality with generative AI.</p>
       <p class="mt-1"><strong>Action:</strong> Tailored workshops, clearance checklists and IP-safe workflows.</p>
       <p class="mt-1"><strong>Effect:</strong> Faster production while reducing infringement risk.</p>
     </article>
 
     <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-      <h3 class="text-xl font-semibold text-blue-700">Research data privacy at scale</h3>
+      <h3 class="text-xl font-semibold text-blue-700">Personvern i forskningsprosjekter i skala</h3>
       <p class="mt-3"><strong>Problem:</strong> Externally funded projects requiring privacy compliance.</p>
       <p class="mt-1"><strong>Action:</strong> Completed <strong>300+ data privacy assessments</strong> (DPIA/RoPA, DPA templates).</p>
       <p class="mt-1"><strong>Effect:</strong> Ethics and data-protection approvals with smoother audits.</p>
     </article>
 
     <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-      <h3 class="text-xl font-semibold text-blue-700">Grant proposal support</h3>
+      <h3 class="text-xl font-semibold text-blue-700">Støtte til søknadsprosesser</h3>
       <p class="mt-3"><strong>Problem:</strong> Teams needed competitive proposals.</p>
       <p class="mt-1"><strong>Action:</strong> Supported <strong>100+</strong> proposals for the Research Council of Norway, Horizon Europe, NordForsk and others.</p>
       <p class="mt-1"><strong>Effect:</strong> Stronger scores and a higher win rate.</p>
@@ -165,13 +165,13 @@
 </section>
 
     <section id="contact" class="contact container">
-        <h2>Contact</h2>
-        <p>Tell us briefly what you need help with. We reply within 1–2 business days.</p>
-        <p><a href="mailto:contact@rdnordic.com?subject=Enquiry%20from%20R%26D%20Nordic">Send us an email</a></p>
+        <h2>Kontakt</h2>
+        <p>Skriv kort hva du trenger hjelp med. Vi svarer innen 1–2 arbeidsdager.</p>
+        <p><a href="mailto:contact@rdnordic.com">Send oss en e-post</a></p>
     </section>
 
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="#contact">Contact</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/no/privacy.html">Personvern</a> | <a href="#contact">Kontakt</a></p>
     </footer>
 </body>
 </html>

--- a/no/privacy.html
+++ b/no/privacy.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Personvernerklæring | R&D Nordic</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar container">
+            <a class="logo" href="index.html#hero">R&D Nordic</a>
+            <ul class="nav-links">
+                <li><a href="index.html#hero">Hjem</a></li>
+                <li><a href="index.html#services">Hva gjør vi</a></li>
+                <li><a href="index.html#why-us">Hvorfor velge oss</a></li>
+                <li><a href="index.html#cases">Erfaringer</a></li>
+                <li><a href="index.html#contact">Kontakt</a></li>
+            </ul>
+            <span class="ml-4 text-sm">
+                <a href="/">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/" aria-current="page" class="font-semibold">NO</a>
+            </span>
+        </nav>
+    </header>
+    <main class="container py-8">
+        <h1>Personvernerklæring</h1>
+        <p>Vi bruker ikke informasjonskapsler (cookies), analyseverktøy eller tredjeparts sporing. De eneste personopplysningene vi mottar er det du selv sender oss på e-post.</p>
+
+        <h2>Hvem vi er</h2>
+        <p>R&amp;D Nordic. E-post: <a href="mailto:contact@rdnordic.com">contact@rdnordic.com</a>.</p>
+
+        <h2>Hvilke data vi behandler</h2>
+        <ul>
+          <li><strong>Meldinger du sender oss</strong> (e-postadresse, navn hvis oppgitt, selve meldingen og eventuelle vedlegg) slik at vi kan svare og følge opp.</li>
+        </ul>
+
+        <h2>Nettsted og drift</h2>
+        <p>Nettstedet er et statisk nettsted driftet på GitHub Pages. GitHub kan loggføre besøkendes IP-adresser for sikkerhet og misbruksvern. Vi har ikke tilgang til disse loggene og bruker dem ikke. Se GitHubs personvernerklæring for detaljer.</p>
+
+        <h2>E-post</h2>
+        <p>Vi bruker Proton Mail som e-postleverandør. Meldinger i vår innboks lagres med null-tilgangskryptering.</p>
+
+        <h2>Behandlingsgrunnlag</h2>
+        <p>GDPR art. 6(1)(b) (tiltak før avtale) og art. 6(1)(f) (vår berettigede interesse i å besvare henvendelser og føre nødvendige arkiv).</p>
+
+        <h2>Lagringstid</h2>
+        <p>Henvendelser lagres inntil 12 måneder og slettes deretter, med mindre lovpålagte krav tilsier lengre lagring. Du kan be om tidligere sletting.</p>
+
+        <h2>Dine rettigheter</h2>
+        <p>Du kan be om innsyn, retting, sletting, begrensning, eller protestere. Du kan også klage til Datatilsynet.</p>
+
+        <h2>Kontakt</h2>
+        <p><a href="mailto:contact@rdnordic.com">contact@rdnordic.com</a></p>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
+    </footer>
+</body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -19,6 +19,11 @@
                 <li><a href="index.html#cases">Cases</a></li>
                 <li><a href="index.html#contact">Contact</a></li>
             </ul>
+            <span class="ml-4 text-sm">
+                <a href="/" aria-current="page" class="font-semibold">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/">NO</a>
+            </span>
         </nav>
     </header>
     <main class="container py-8">


### PR DESCRIPTION
## Summary
- add hreflang metadata and language toggle to English pages
- add Norwegian home and privacy pages with translated content
- add EN/NO switcher across pages for navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba837544b88323b8c87ef9d5876441