### PR TITLE
Add language switcher to English service pages

### DIFF
--- a/services/ai-ethics.html
+++ b/services/ai-ethics.html
@@ -8,6 +8,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../style.css">
+    <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/ai-ethics.html">
+    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/ai-ethics.html">
+    <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/ai-ethics.html">
 </head>
 <body>
     <header class="site-header">
@@ -20,6 +23,11 @@
                 <li><a href="../index.html#cases">Cases</a></li>
                 <li><a href="../index.html#contact">Contact</a></li>
             </ul>
+            <span class="ml-4 text-sm">
+                <a href="/services/ai-ethics.html" aria-current="page" class="font-semibold">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/services/ai-ethics.html">NO</a>
+            </span>
         </nav>
     </header>
     <main class="container py-8">

--- a/services/grant-funding.html
+++ b/services/grant-funding.html
@@ -8,6 +8,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../style.css">
+    <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/grant-funding.html">
+    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/grant-funding.html">
+    <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/grant-funding.html">
 </head>
 <body>
     <header class="site-header">
@@ -20,6 +23,11 @@
                 <li><a href="../index.html#cases">Cases</a></li>
                 <li><a href="../index.html#contact">Contact</a></li>
             </ul>
+            <span class="ml-4 text-sm">
+                <a href="/services/grant-funding.html" aria-current="page" class="font-semibold">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/services/grant-funding.html">NO</a>
+            </span>
         </nav>
     </header>
     <main class="container py-8">

--- a/services/privacy-gdpr.html
+++ b/services/privacy-gdpr.html
@@ -8,6 +8,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../style.css">
+    <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/privacy-gdpr.html">
+    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/privacy-gdpr.html">
+    <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/privacy-gdpr.html">
 </head>
 <body>
     <header class="site-header">
@@ -20,6 +23,11 @@
                 <li><a href="../index.html#cases">Cases</a></li>
                 <li><a href="../index.html#contact">Contact</a></li>
             </ul>
+            <span class="ml-4 text-sm">
+                <a href="/services/privacy-gdpr.html" aria-current="page" class="font-semibold">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/services/privacy-gdpr.html">NO</a>
+            </span>
         </nav>
     </header>
     <main class="container py-8">

--- a/services/project-management.html
+++ b/services/project-management.html
@@ -8,6 +8,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="../style.css">
+    <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/project-management.html">
+    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/project-management.html">
+    <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/project-management.html">
 </head>
 <body>
     <header class="site-header">
@@ -20,6 +23,11 @@
                 <li><a href="../index.html#cases">Cases</a></li>
                 <li><a href="../index.html#contact">Contact</a></li>
             </ul>
+            <span class="ml-4 text-sm">
+                <a href="/services/project-management.html" aria-current="page" class="font-semibold">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/services/project-management.html">NO</a>
+            </span>
         </nav>
     </header>
     <main class="container py-8">


### PR DESCRIPTION
## Summary
- Add hreflang alternate links for English service pages
- Add EN/NO language switcher nav items on English service pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2f8ea75883239c7496564e69e3a1