### PR TITLE
Translate Norwegian pages

### DIFF
--- a/no/index.html
+++ b/no/index.html
@@ -31,8 +31,8 @@
     </header>
 
     <section id="hero" class="hero">
-        <img src="../images/northern lights.jpg" alt="Nordic landscape" class="hero-img">
-        <img src="../images/rndnordiclogo.png" alt="R&D Nordic logo" class="hero-logo">
+        <img src="../images/northern lights.jpg" alt="Nordisk landskap" class="hero-img">
+        <img src="../images/rndnordiclogo.png" alt="R&D Nordic-logo" class="hero-logo">
         <div class="hero-text container max-w-3xl mx-auto text-center">
             <h1>Fremtidsrettet rådgivning</h1>
             <p>Prosjektledelse, personvern, etikk, IPR, KI-integrasjon og forskningsfinansiering.</p>
@@ -42,57 +42,57 @@
     <section id="services" class="services container">
         <h2 class="text-3xl font-semibold text-[#005b96]">Hva vi gjør</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6 items-stretch">
-            <a href="/services/project-management.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+            <a href="/no/services/project-management.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
                 <h3 class="text-xl font-semibold text-[#005b96] mb-2">Prosjektledelse</h3>
                 <p class="text-gray-700 mb-4">Plan, leveranse og gevinstrealisering.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
-                    <li>Planning & execution</li>
-                    <li>Agile methodologies</li>
-                    <li>Risk management</li>
+                    <li>Planlegging og gjennomføring</li>
+                    <li>Smidige metoder</li>
+                    <li>Risikostyring</li>
                 </ul>
-                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Les mer
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                     </svg>
                 </span>
             </a>
-            <a href="/services/privacy-gdpr.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+            <a href="/no/services/privacy-gdpr.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
                 <h3 class="text-xl font-semibold text-[#005b96] mb-2">Personvern og GDPR</h3>
                 <p class="text-gray-700 mb-4">DPIA, avtaler, dataminimering og opplæring.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
-                    <li>Compliance assessments</li>
-                    <li>Privacy policies</li>
-                    <li>Security best practices</li>
+                    <li>Samsvarsvurderinger</li>
+                    <li>Personvernerklæringer</li>
+                    <li>Sikkerhetsrutiner</li>
                 </ul>
-                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Les mer
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                     </svg>
                 </span>
             </a>
-            <a href="/services/ai-ethics.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+            <a href="/no/services/ai-ethics.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
                 <h3 class="text-xl font-semibold text-[#005b96] mb-2">KI-integrasjon og etikk</h3>
                 <p class="text-gray-700 mb-4">Fra pilot til skala. AI Act-klar styring.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
-                    <li>Automation strategies</li>
-                    <li>Ethical guidelines</li>
-                    <li>Custom AI solutions</li>
+                    <li>Automatiseringsstrategier</li>
+                    <li>Etiske retningslinjer</li>
+                    <li>Skreddersydde KI-løsninger</li>
                 </ul>
-                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Les mer
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                     </svg>
                 </span>
             </a>
-            <a href="/services/grant-funding.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+            <a href="/no/services/grant-funding.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
                 <h3 class="text-xl font-semibold text-[#005b96] mb-2">Forskningsmidler</h3>
                 <p class="text-gray-700 mb-4">Strategi, konsortier og leveranseplaner.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
-                    <li>Opportunity scanning</li>
-                    <li>Application support</li>
-                    <li>Budget planning</li>
+                    <li>Utlysingssøk</li>
+                    <li>Støtte i søknadsarbeid</li>
+                    <li>Budsjettplanlegging</li>
                 </ul>
-                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Les mer
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                     </svg>
@@ -135,34 +135,34 @@
   <h2 class="text-2xl md:text-3xl font-semibold">Utvalgte caser</h2>
   <div class="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-6">
     <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-      <h3 class="text-xl font-semibold text-blue-700">AI-opplæring for offentlig og privat sektor</h3>
-      <p class="mt-3"><strong>Problem:</strong> Organisations unsure how to adopt AI responsibly.</p>
-      <p class="mt-1"><strong>Action:</strong> Delivered training on AI, IPR, Ethics and Data Privacy with practical use cases.</p>
-      <p class="mt-1"><strong>Effect:</strong> Teams adopted safe, effective workflows and reduced risk.</p>
-    </article>
+        <h3 class="text-xl font-semibold text-blue-700">AI-opplæring for offentlig og privat sektor</h3>
+        <p class="mt-3"><strong>Problem:</strong> Organisasjoner usikre på hvordan de kan ta i bruk KI på en ansvarlig måte.</p>
+        <p class="mt-1"><strong>Tiltak:</strong> Levererte opplæring i KI, IPR, etikk og personvern med praktiske eksempler.</p>
+        <p class="mt-1"><strong>Resultat:</strong> Team tok i bruk trygge, effektive arbeidsflyter og reduserte risiko.</p>
+      </article>
 
-    <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-      <h3 class="text-xl font-semibold text-blue-700">KI og IPR for kreative næringer</h3>
-      <p class="mt-3"><strong>Problem:</strong> Arts partners concerned about rights and originality with generative AI.</p>
-      <p class="mt-1"><strong>Action:</strong> Tailored workshops, clearance checklists and IP-safe workflows.</p>
-      <p class="mt-1"><strong>Effect:</strong> Faster production while reducing infringement risk.</p>
-    </article>
+      <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
+        <h3 class="text-xl font-semibold text-blue-700">KI og IPR for kreative næringer</h3>
+        <p class="mt-3"><strong>Problem:</strong> Kunstaktører bekymret for rettigheter og originalitet med generativ KI.</p>
+        <p class="mt-1"><strong>Tiltak:</strong> Skreddersydde workshops, sjekklister og rettighetssikre arbeidsflyter.</p>
+        <p class="mt-1"><strong>Resultat:</strong> Raskere produksjon med lavere risiko for brudd.</p>
+      </article>
 
-    <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-      <h3 class="text-xl font-semibold text-blue-700">Personvern i forskningsprosjekter i skala</h3>
-      <p class="mt-3"><strong>Problem:</strong> Externally funded projects requiring privacy compliance.</p>
-      <p class="mt-1"><strong>Action:</strong> Completed <strong>300+ data privacy assessments</strong> (DPIA/RoPA, DPA templates).</p>
-      <p class="mt-1"><strong>Effect:</strong> Ethics and data-protection approvals with smoother audits.</p>
-    </article>
+      <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
+        <h3 class="text-xl font-semibold text-blue-700">Personvern i forskningsprosjekter i skala</h3>
+        <p class="mt-3"><strong>Problem:</strong> Eksternt finansierte prosjekter som krever personvern-etterlevelse.</p>
+        <p class="mt-1"><strong>Tiltak:</strong> Gjennomførte <strong>300+ personvernvurderinger</strong> (DPIA/RoPA, avtaleskjema).</p>
+        <p class="mt-1"><strong>Resultat:</strong> Etikk- og personvern-godkjenninger med smidigere revisjoner.</p>
+      </article>
 
-    <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-      <h3 class="text-xl font-semibold text-blue-700">Støtte til søknadsprosesser</h3>
-      <p class="mt-3"><strong>Problem:</strong> Teams needed competitive proposals.</p>
-      <p class="mt-1"><strong>Action:</strong> Supported <strong>100+</strong> proposals for the Research Council of Norway, Horizon Europe, NordForsk and others.</p>
-      <p class="mt-1"><strong>Effect:</strong> Stronger scores and a higher win rate.</p>
-    </article>
-  </div>
-</section>
+      <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
+        <h3 class="text-xl font-semibold text-blue-700">Støtte til søknadsprosesser</h3>
+        <p class="mt-3"><strong>Problem:</strong> Team trengte konkurransedyktige søknader.</p>
+        <p class="mt-1"><strong>Tiltak:</strong> Bistod med <strong>100+</strong> søknader til Forskningsrådet, Horisont Europa, NordForsk m.fl.</p>
+        <p class="mt-1"><strong>Resultat:</strong> Bedre evalueringer og høyere tilslagsrate.</p>
+      </article>
+    </div>
+  </section>
 
     <section id="contact" class="contact container">
         <h2>Kontakt</h2>
@@ -171,7 +171,7 @@
     </section>
 
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/no/privacy.html">Personvern</a> | <a href="#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="#contact">Kontakt</a></p>
     </footer>
 </body>
 </html>

--- a/no/privacy.html
+++ b/no/privacy.html
@@ -57,7 +57,7 @@
         <p><a href="mailto:contact@rdnordic.com">contact@rdnordic.com</a></p>
     </main>
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
     </footer>
 </body>
 </html>

--- a/no/services/ai-ethics.html
+++ b/no/services/ai-ethics.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KI-integrasjon og etikk | R&amp;D Nordic</title>
+    <meta name="description" content="Etiske KI-strategier som balanserer innovasjon med ansvarlighet og åpenhet.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../style.css">
+      <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/ai-ethics.html">
+      <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/ai-ethics.html">
+      <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/ai-ethics.html">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar container">
+              <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+              <ul class="nav-links">
+                  <li><a href="../index.html#hero">Hjem</a></li>
+                  <li><a href="../index.html#services">Hva gjør vi</a></li>
+                  <li><a href="../index.html#why-us">Hvorfor velge oss</a></li>
+                  <li><a href="../index.html#cases">Erfaringer</a></li>
+                  <li><a href="../index.html#contact">Kontakt</a></li>
+              </ul>
+              <span class="ml-4 text-sm">
+                  <a href="/services/ai-ethics.html">EN</a>
+                  <span class="mx-1">|</span>
+                  <a href="/no/services/ai-ethics.html" aria-current="page" class="font-semibold">NO</a>
+              </span>
+          </nav>
+      </header>
+      <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">KI-integrasjon og etikk</h1>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Utfordringen vi løser</h2>
+            <p class="text-gray-700">Organisasjoner ønsker produktiviteten fra KI, men frykter skjevhet, manglende åpenhet og regulatorisk usikkerhet.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Vår tilnærming</h2>
+            <p class="text-gray-700">Vi vurderer brukstilfeller, analyserer konsekvenser og bygger styring slik at automatisering forblir transparent og rettferdig.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typiske leveranser</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Workshops om KI-beredskap og risiko</li>
+                <li>Etiske retningslinjer og styringsrammeverk</li>
+                <li>Vurderinger av skjevhet og transparens</li>
+                <li>Støtte til prototyper eller integrasjon</li>
+            </ul>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Resultater</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Ansvarlige, forklarbare KI-løsninger</li>
+                <li>Redusert etisk og regulatorisk risiko</li>
+                <li>Tillit hos interessenter og myndigheter</li>
+            </ul>
+        </section>
+        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book et møte</a>
+      </main>
+      <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
+      </footer>
+    </body>
+    </html>
+

--- a/no/services/grant-funding.html
+++ b/no/services/grant-funding.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Forskningsmidler | R&amp;D Nordic</title>
+    <meta name="description" content="Ekspertstøtte til å finne utlysninger, utvikle søknader og sikre forskningsmidler.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../style.css">
+      <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/grant-funding.html">
+      <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/grant-funding.html">
+      <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/grant-funding.html">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar container">
+              <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+              <ul class="nav-links">
+                  <li><a href="../index.html#hero">Hjem</a></li>
+                  <li><a href="../index.html#services">Hva gjør vi</a></li>
+                  <li><a href="../index.html#why-us">Hvorfor velge oss</a></li>
+                  <li><a href="../index.html#cases">Erfaringer</a></li>
+                  <li><a href="../index.html#contact">Kontakt</a></li>
+              </ul>
+              <span class="ml-4 text-sm">
+                  <a href="/services/grant-funding.html">EN</a>
+                  <span class="mx-1">|</span>
+                  <a href="/no/services/grant-funding.html" aria-current="page" class="font-semibold">NO</a>
+              </span>
+          </nav>
+      </header>
+      <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Forskningsmidler</h1>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Utfordringen vi løser</h2>
+            <p class="text-gray-700">Å finne riktig program og utarbeide en konkurransedyktig søknad er tidkrevende og komplekst.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Vår tilnærming</h2>
+            <p class="text-gray-700">Vi søker etter utlysninger, former konsepter og veileder innsendingen for å møte forventningene til finansieringsgiver.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typiske leveranser</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Søk i finansieringsmuligheter</li>
+                <li>Konseptnotater og utkast til søknader</li>
+                <li>Budsjett- og effektbeskrivelser</li>
+                <li>Håndtering av innsending</li>
+            </ul>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Resultater</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Høyere tilslagsrate</li>
+                <li>Klare prosjektplaner i tråd med krav</li>
+                <li>Ressurser sikret for å drive innovasjon</li>
+            </ul>
+        </section>
+        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book et møte</a>
+      </main>
+      <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
+      </footer>
+    </body>
+    </html>
+

--- a/no/services/privacy-gdpr.html
+++ b/no/services/privacy-gdpr.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Personvern og GDPR | R&amp;D Nordic</title>
+    <meta name="description" content="Praktisk GDPR-veiledning for å kartlegge data, redusere risiko og bygge tillitsfulle prosesser.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../style.css">
+      <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/privacy-gdpr.html">
+      <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/privacy-gdpr.html">
+      <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/privacy-gdpr.html">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar container">
+              <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+              <ul class="nav-links">
+                  <li><a href="../index.html#hero">Hjem</a></li>
+                  <li><a href="../index.html#services">Hva gjør vi</a></li>
+                  <li><a href="../index.html#why-us">Hvorfor velge oss</a></li>
+                  <li><a href="../index.html#cases">Erfaringer</a></li>
+                  <li><a href="../index.html#contact">Kontakt</a></li>
+              </ul>
+              <span class="ml-4 text-sm">
+                  <a href="/services/privacy-gdpr.html">EN</a>
+                  <span class="mx-1">|</span>
+                  <a href="/no/services/privacy-gdpr.html" aria-current="page" class="font-semibold">NO</a>
+              </span>
+          </nav>
+      </header>
+      <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Personvern og GDPR</h1>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Utfordringen vi løser</h2>
+            <p class="text-gray-700">Mange organisasjoner samler inn personopplysninger uten full oversikt, noe som skaper mangler i etterlevelsen og risiko for gebyrer.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Vår tilnærming</h2>
+            <p class="text-gray-700">Vi kartlegger dataflyt, vurderer risiko og etablerer styring slik at personvernforpliktelser oppfylles.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typiske leveranser</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Oversikter over behandlingsaktiviteter</li>
+                <li>Personvernkonsekvensvurderinger</li>
+                <li>Personvernerklæringer og samtykketekster</li>
+                <li>Opplæring og bevisstgjøring for ansatte</li>
+            </ul>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Resultater</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Redusert risiko for brudd og bøter</li>
+                <li>Dokumentert etterlevelse av regelverk</li>
+                <li>Økt tillit fra kunder og partnere</li>
+            </ul>
+        </section>
+        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book et møte</a>
+      </main>
+      <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
+      </footer>
+    </body>
+    </html>
+

--- a/no/services/project-management.html
+++ b/no/services/project-management.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prosjektledelse | R&amp;D Nordic</title>
+    <meta name="description" content="Strukturert prosjektledelse som holder milepæler, risiko og team på sporet.">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="../style.css">
+      <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/project-management.html">
+      <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/project-management.html">
+      <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/project-management.html">
+</head>
+<body>
+    <header class="site-header">
+        <nav class="navbar container">
+              <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
+              <ul class="nav-links">
+                  <li><a href="../index.html#hero">Hjem</a></li>
+                  <li><a href="../index.html#services">Hva gjør vi</a></li>
+                  <li><a href="../index.html#why-us">Hvorfor velge oss</a></li>
+                  <li><a href="../index.html#cases">Erfaringer</a></li>
+                  <li><a href="../index.html#contact">Kontakt</a></li>
+              </ul>
+              <span class="ml-4 text-sm">
+                  <a href="/services/project-management.html">EN</a>
+                  <span class="mx-1">|</span>
+                  <a href="/no/services/project-management.html" aria-current="page" class="font-semibold">NO</a>
+              </span>
+          </nav>
+      </header>
+      <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Prosjektledelse</h1>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Utfordringen vi løser</h2>
+            <p class="text-gray-700">Team sliter med skiftende prioriteringer, begrensede ressurser og uklare roller som forsinker tidsplaner.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Vår tilnærming</h2>
+            <p class="text-gray-700">Vi kombinerer strukturert planlegging med smidige rutiner for å skape klarhet, håndtere risiko og holde interessenter samkjørt.</p>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typiske leveranser</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Prosjektmandater og veikart</li>
+                <li>Sprintplaner og oppgavetavler</li>
+                <li>Risiko- og avviksregistre</li>
+                <li>Kommunikasjonsplaner for interessenter</li>
+            </ul>
+        </section>
+        <section class="mb-6">
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Resultater</h2>
+            <ul class="list-disc pl-5 text-gray-700 space-y-1">
+                <li>Klare milepæler og ansvar</li>
+                <li>Kontrollerte risikoer og omfang</li>
+                <li>Prosjekter levert i tide</li>
+            </ul>
+        </section>
+        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book et møte</a>
+      </main>
+      <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
+      </footer>
+    </body>
+    </html>
+


### PR DESCRIPTION
## Summary
- localize Norwegian homepage sections, case studies, alt text, and links
- translate privacy notice footer text
- add Norwegian versions of service pages with localized content

## Testing
- `npx htmlhint no/index.html no/privacy.html no/services/project-management.html no/services/privacy-gdpr.html no/services/ai-ethics.html no/services/grant-funding.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c69949e883238d1e6935d8a32819