### PR TITLE
Add creative arts support overview to services section

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,16 @@
                     </svg>
                 </span>
             </a>
+            <div class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg">
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Creative Arts Support</h3>
+                <p class="text-gray-700 mb-4">We guide film, TV, game, and art schools on responsible AI use in storytelling and production.</p>
+                <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
+                    <li>Ethics, IPR &amp; data privacy frameworks</li>
+                    <li>Workshops for developers, programmers, producers &amp; scriptwriters</li>
+                    <li>Artist-centric AI guidelines and playbooks</li>
+                </ul>
+                <p class="mt-auto text-gray-700">Experienced collaborating with multidisciplinary creative teams to balance innovation with rights protection.</p>
+            </div>
         </div>
         <details class="mt-8 text-left">
             <summary class="cursor-pointer text-[#005b96] font-semibold">More specialties</summary>


### PR DESCRIPTION
## Summary
- add a creative arts support card to the What We Do section
- highlight experience with film, TV, game, and art school collaborators on AI ethics, IPR, and data privacy guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13d3160b083238037ed1e13cd2fd3