### PR TITLE
Align Norwegian site with English content

### DIFF
--- a/no/index.html
+++ b/no/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>R&D Nordic</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="../style.css">
-    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/">
+    <link rel="stylesheet" href="/style.css">
     <link rel="alternate" hreflang="en" href="https://rdnordic.com/">
+    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/">
     <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/">
 </head>
 <body>
@@ -16,11 +16,11 @@
         <nav class="navbar container">
             <a class="logo" href="#hero">R&D Nordic</a>
             <ul class="nav-links">
-                <li><a href="#hero">Hjem</a></li>
-                <li><a href="#services">Hva gjør vi</a></li>
-                <li><a href="#why-us">Hvorfor velge oss</a></li>
-                <li><a href="#cases">Erfaringer</a></li>
-                <li><a href="#contact">Kontakt</a></li>
+                <li><a href="#hero">Home</a></li>
+                <li><a href="#services">What We Do</a></li>
+                <li><a href="#why-us">Why Us</a></li>
+                <li><a href="#cases">Cases</a></li>
+                <li><a href="#contact">Contact</a></li>
             </ul>
             <span class="ml-4 text-sm">
                 <a href="/">EN</a>
@@ -31,90 +31,90 @@
     </header>
 
     <section id="hero" class="hero">
-        <img src="../images/northern lights.jpg" alt="Nordisk landskap" class="hero-img">
-        <img src="../images/rndnordiclogo.png" alt="R&D Nordic-logo" class="hero-logo">
+        <img src="/images/northern lights.jpg" alt="Nordic landscape" class="hero-img">
+        <img src="/images/rndnordiclogo.png" alt="R&D Nordic logo" class="hero-logo">
         <div class="hero-text container max-w-3xl mx-auto text-center">
-            <h1>Fremtidsrettet rådgivning</h1>
-            <p>Prosjektledelse, personvern, etikk, IPR, KI-integrasjon og forskningsfinansiering.</p>
+            <h1>Future-Proof Consulting</h1>
+            <p>Project management, data privacy, AI integration and research funding guidance.</p>
         </div>
     </section>
 
     <section id="services" class="services container">
-        <h2 class="text-3xl font-semibold text-[#005b96]">Hva vi gjør</h2>
+        <h2 class="text-3xl font-semibold text-[#005b96]">What We Do</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-6 items-stretch">
-            <a href="/no/services/project-management.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Prosjektledelse</h3>
-                <p class="text-gray-700 mb-4">Plan, leveranse og gevinstrealisering.</p>
+            <a href="/services/project-management.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Project Management</h3>
+                <p class="text-gray-700 mb-4">We plan and drive projects from concept to delivery with clarity and agility.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
-                    <li>Planlegging og gjennomføring</li>
-                    <li>Smidige metoder</li>
-                    <li>Risikostyring</li>
+                    <li>Planning &amp; execution</li>
+                    <li>Agile methodologies</li>
+                    <li>Risk management</li>
                 </ul>
-                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Les mer
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                     </svg>
                 </span>
             </a>
-            <a href="/no/services/privacy-gdpr.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Personvern og GDPR</h3>
-                <p class="text-gray-700 mb-4">DPIA, avtaler, dataminimering og opplæring.</p>
+            <a href="/services/privacy-gdpr.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Privacy &amp; GDPR</h3>
+                <p class="text-gray-700 mb-4">We safeguard data handling and align operations with EU privacy regulations.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
-                    <li>Samsvarsvurderinger</li>
-                    <li>Personvernerklæringer</li>
-                    <li>Sikkerhetsrutiner</li>
+                    <li>Compliance assessments</li>
+                    <li>Privacy policies</li>
+                    <li>Security best practices</li>
                 </ul>
-                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Les mer
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                     </svg>
                 </span>
             </a>
-            <a href="/no/services/ai-ethics.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">KI-integrasjon og etikk</h3>
-                <p class="text-gray-700 mb-4">Fra pilot til skala. AI Act-klar styring.</p>
+            <a href="/services/ai-ethics.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">AI Integration &amp; Ethics</h3>
+                <p class="text-gray-700 mb-4">We design responsible AI approaches that accelerate workflows without compromising trust.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
-                    <li>Automatiseringsstrategier</li>
-                    <li>Etiske retningslinjer</li>
-                    <li>Skreddersydde KI-løsninger</li>
+                    <li>Automation strategies</li>
+                    <li>Ethical guidelines</li>
+                    <li>Custom AI solutions</li>
                 </ul>
-                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Les mer
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                     </svg>
                 </span>
             </a>
-            <a href="/no/services/grant-funding.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Forskningsmidler</h3>
-                <p class="text-gray-700 mb-4">Strategi, konsortier og leveranseplaner.</p>
+            <a href="/services/grant-funding.html" class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg group">
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Grant Funding</h3>
+                <p class="text-gray-700 mb-4">We identify funding opportunities and craft proposals that secure the resources you need.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
-                    <li>Utlysingssøk</li>
-                    <li>Støtte i søknadsarbeid</li>
-                    <li>Budsjettplanlegging</li>
+                    <li>Opportunity scanning</li>
+                    <li>Application support</li>
+                    <li>Budget planning</li>
                 </ul>
-                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Les mer
+                <span class="mt-auto text-[#005b96] inline-flex items-center font-semibold">Learn more
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 ml-1 transition-transform group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                     </svg>
                 </span>
             </a>
             <div class="flex flex-col h-full p-6 bg-white rounded-lg shadow-md border border-transparent transition transform hover:border-white/30 hover:translate-y-0.5 hover:shadow-lg">
-                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Støtte til kreative næringer</h3>
-                <p class="text-gray-700 mb-4">Vi veileder film-, TV-, spill- og kunstmiljøer i ansvarlig KI-bruk i historiefortelling og produksjon.</p>
+                <h3 class="text-xl font-semibold text-[#005b96] mb-2">Creative Arts Support</h3>
+                <p class="text-gray-700 mb-4">We guide film, TV, game, and art schools on responsible AI use in storytelling and production.</p>
                 <ul class="list-disc pl-5 text-gray-700 space-y-1 mb-4">
-                    <li>Etikk-, IPR- og personvernrammeverk</li>
-                    <li>Workshops for utviklere, programmerere, produsenter og manusforfattere</li>
-                    <li>Kunstnerorienterte KI-retningslinjer og handlingsplaner</li>
+                    <li>Ethics, IPR &amp; data privacy frameworks</li>
+                    <li>Workshops for developers, programmers, producers &amp; scriptwriters</li>
+                    <li>Artist-centric AI guidelines and playbooks</li>
                 </ul>
-                <p class="mt-auto text-gray-700">Erfaring med tverrfaglige kreative team for å balansere innovasjon og rettighetsbeskyttelse.</p>
+                <p class="mt-auto text-gray-700">Experienced collaborating with multidisciplinary creative teams to balance innovation with rights protection.</p>
             </div>
         </div>
         <details class="mt-8 text-left">
-            <summary class="cursor-pointer text-[#005b96] font-semibold">Flere spesialiteter</summary>
+            <summary class="cursor-pointer text-[#005b96] font-semibold">More specialties</summary>
             <ul class="mt-4 list-disc pl-5 text-gray-700 space-y-1">
-                <li>Forskningsstrategi og evalueringsrammer</li>
-                <li>Informasjonssikkerhet</li>
-                <li>Opplæring for ledere og ansatte</li>
+                <li><span class="font-semibold">Research Strategy:</span> roadmap development, collaboration advice, innovation projects.</li>
+                <li><span class="font-semibold">Workshops &amp; Training:</span> tailored sessions to upskill teams in new methods.</li>
+                <li><span class="font-semibold">Process Optimization:</span> efficiency audits and continuous improvement frameworks.</li>
             </ul>
         </details>
     </section>
@@ -122,19 +122,19 @@
 <!-- Why Choose Us Strip -->
 <section id="why-us" class="why-us-section">
   <div class="container">
-    <h2 class="text-3xl font-semibold text-[#005b96] text-center">Hvorfor velge oss</h2>
+    <h2 class="text-3xl font-semibold text-[#005b96] text-center">Why Choose Us</h2>
     <ul class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-6 list-none p-0">
       <li class="bg-white rounded-lg shadow-md p-6 text-center">
         <span class="text-4xl font-bold text-[#005b96]">50+</span>
-        <p class="mt-2 text-gray-700">DPIA gjennomført</p>
+        <p class="mt-2 text-gray-700">DPIAs completed</p>
       </li>
       <li class="bg-white rounded-lg shadow-md p-6 text-center">
         <span class="text-4xl font-bold text-[#005b96]">100&nbsp;MNOK</span>
-        <p class="mt-2 text-gray-700">Søknader kvalitetssikret</p>
+        <p class="mt-2 text-gray-700">quality-assured</p>
       </li>
       <li class="bg-white rounded-lg shadow-md p-6 text-center">
         <span class="text-4xl font-bold text-[#005b96]">25M&nbsp;EUR</span>
-        <p class="mt-2 text-gray-700">finansiering sikret</p>
+        <p class="mt-2 text-gray-700">funding secured</p>
       </li>
     </ul>
   </div>
@@ -142,48 +142,48 @@
 
 <!-- Cases Section -->
 <section id="cases" class="cases container">
-  <h2 class="text-2xl md:text-3xl font-semibold">Utvalgte caser</h2>
+  <h2 class="text-2xl md:text-3xl font-semibold">Featured cases</h2>
   <div class="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-6">
     <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-        <h3 class="text-xl font-semibold text-blue-700">AI-opplæring for offentlig og privat sektor</h3>
-        <p class="mt-3"><strong>Problem:</strong> Organisasjoner usikre på hvordan de kan ta i bruk KI på en ansvarlig måte.</p>
-        <p class="mt-1"><strong>Tiltak:</strong> Levererte opplæring i KI, IPR, etikk og personvern med praktiske eksempler.</p>
-        <p class="mt-1"><strong>Resultat:</strong> Team lærer å ta i bruk trygge, effektive arbeidsflyter, risiko er redusert og arbeidsflyter effektiviseres.</p>
-      </article>
+      <h3 class="text-xl font-semibold text-blue-700">AI training for public &amp; private sector</h3>
+      <p class="mt-3"><strong>Problem:</strong> Organisations unsure how to adopt AI responsibly.</p>
+      <p class="mt-1"><strong>Action:</strong> Delivered training on AI, IPR, Ethics and Data Privacy with practical use cases.</p>
+      <p class="mt-1"><strong>Effect:</strong> Teams adopted safe, effective workflows and reduced risk.</p>
+    </article>
 
-      <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-        <h3 class="text-xl font-semibold text-blue-700">KI og IPR for kreative næringer</h3>
-        <p class="mt-3"><strong>Problem:</strong> Kunstaktører bekymret for rettigheter og originalitet med generativ KI.</p>
-        <p class="mt-1"><strong>Tiltak:</strong> Skreddersydde workshops, sjekklister og rettighetssikre arbeidsflyter.</p>
-        <p class="mt-1"><strong>Resultat:</strong> Raskere produksjon med lavere risiko for brudd.</p>
-      </article>
+    <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
+      <h3 class="text-xl font-semibold text-blue-700">AI &amp; IPR for creative industries</h3>
+      <p class="mt-3"><strong>Problem:</strong> Arts partners concerned about rights and originality with generative AI.</p>
+      <p class="mt-1"><strong>Action:</strong> Tailored workshops, clearance checklists and IP-safe workflows.</p>
+      <p class="mt-1"><strong>Effect:</strong> Faster production while reducing infringement risk.</p>
+    </article>
 
-      <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-        <h3 class="text-xl font-semibold text-blue-700">Personvern i forskningsprosjekter i skala</h3>
-        <p class="mt-3"><strong>Problem:</strong> Eksternt finansierte prosjekter som krever personvern-etterlevelse.</p>
-        <p class="mt-1"><strong>Tiltak:</strong> Gjennomførte <strong>300+ personvernvurderinger</strong> (DPIA/RoPA, avtaleskjema).</p>
-        <p class="mt-1"><strong>Resultat:</strong> Etikk- og personvern-godkjenninger med smidigere revisjoner.</p>
-      </article>
+    <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
+      <h3 class="text-xl font-semibold text-blue-700">Research data privacy at scale</h3>
+      <p class="mt-3"><strong>Problem:</strong> Externally funded projects requiring privacy compliance.</p>
+      <p class="mt-1"><strong>Action:</strong> Completed <strong>300+ data privacy assessments</strong> (DPIA/RoPA, DPA templates).</p>
+      <p class="mt-1"><strong>Effect:</strong> Ethics and data-protection approvals with smoother audits.</p>
+    </article>
 
-      <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
-        <h3 class="text-xl font-semibold text-blue-700">Støtte til søknadsprosesser</h3>
-        <p class="mt-3"><strong>Problem:</strong> Team trengte konkurransedyktige søknader.</p>
-        <p class="mt-1"><strong>Tiltak:</strong> Har bistått med utviklingen av over <strong>300</strong> søknader til Forskningsrådet, Horisont Europa, NordForsk m.fl.</p>
-        <p class="mt-1"><strong>Resultat:</strong> Bedre evalueringer og høyere tilslagsrate.</p>
-      </article>
-    </div>
-  </section>
+    <article class="rounded-2xl bg-white p-6 shadow border border-slate-200">
+      <h3 class="text-xl font-semibold text-blue-700">Grant proposal support</h3>
+      <p class="mt-3"><strong>Problem:</strong> Teams needed competitive proposals.</p>
+      <p class="mt-1"><strong>Action:</strong> Supported <strong>100+</strong> proposals for the Research Council of Norway, Horizon Europe, NordForsk and others.</p>
+      <p class="mt-1"><strong>Effect:</strong> Stronger scores and a higher win rate.</p>
+    </article>
+  </div>
+</section>
 
     <section id="contact" class="contact container">
-        <h2>Kontakt</h2>
-        <p>Skriv kort hva du trenger hjelp med. Vi svarer innen 1–2 arbeidsdager.</p>
+        <h2>Contact</h2>
+        <p>Tell us briefly what you need help with. We reply within 1–2 business days.</p>
         <div class="contact-card">
-            <a class="contact-link" href="mailto:contact@rdnordic.com?subject=Henvendelse%20fra%20R%26D%20Nordic">Send oss en e-post</a>
+            <a class="contact-link" href="mailto:contact@rdnordic.com?subject=Enquiry%20from%20R%26D%20Nordic">Send us an email</a>
         </div>
     </section>
 
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="#contact">Contact</a></p>
     </footer>
 </body>
 </html>

--- a/no/privacy.html
+++ b/no/privacy.html
@@ -1,63 +1,64 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Personvernerklæring | R&D Nordic</title>
+    <title>Privacy Notice | R&D Nordic</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="/style.css">
 </head>
 <body>
     <header class="site-header">
         <nav class="navbar container">
-            <a class="logo" href="index.html#hero">R&D Nordic</a>
+            <a class="logo" href="/index.html#hero">R&D Nordic</a>
             <ul class="nav-links">
-                <li><a href="index.html#hero">Hjem</a></li>
-                <li><a href="index.html#services">Hva gjør vi</a></li>
-                <li><a href="index.html#why-us">Hvorfor velge oss</a></li>
-                <li><a href="index.html#cases">Erfaringer</a></li>
-                <li><a href="index.html#contact">Kontakt</a></li>
+                <li><a href="/index.html#hero">Home</a></li>
+                <li><a href="/index.html#services">What We Do</a></li>
+                <li><a href="/index.html#why-us">Why Us</a></li>
+                <li><a href="/index.html#cases">Cases</a></li>
+                <li><a href="/index.html#contact">Contact</a></li>
             </ul>
             <span class="ml-4 text-sm">
-                <a href="/">EN</a>
+                <a href="/privacy.html">EN</a>
                 <span class="mx-1">|</span>
-                <a href="/no/" aria-current="page" class="font-semibold">NO</a>
+                <a href="/no/privacy.html" aria-current="page" class="font-semibold">NO</a>
             </span>
         </nav>
     </header>
     <main class="container py-8">
-        <h1>Personvernerklæring</h1>
-        <p>Vi bruker ikke informasjonskapsler (cookies), analyseverktøy eller tredjeparts sporing. De eneste personopplysningene vi mottar er det du selv sender oss på e-post.</p>
+        <h1>Privacy Notice</h1>
 
-        <h2>Hvem vi er</h2>
-        <p>R&amp;D Nordic. E-post: <a href="mailto:contact@rdnordic.com">contact@rdnordic.com</a>.</p>
+        <p>We do not use cookies or analytics and we do not embed third-party tracking scripts. The only personal data we receive is what you choose to send us by email.</p>
 
-        <h2>Hvilke data vi behandler</h2>
+        <h2>Who we are</h2>
+        <p>R&amp;D Nordic. Email: <a href="mailto:contact@rdnordic.com">contact@rdnordic.com</a>.</p>
+
+        <h2>Data we process</h2>
         <ul>
-          <li><strong>Meldinger du sender oss</strong> (e-postadresse, navn hvis oppgitt, selve meldingen og eventuelle vedlegg) slik at vi kan svare og følge opp.</li>
+          <li><strong>Messages you send us</strong> (your email address, name if provided, message and any attachments) so we can reply and follow up.</li>
         </ul>
 
-        <h2>Nettsted og drift</h2>
-        <p>Nettstedet er et statisk nettsted driftet på GitHub Pages. GitHub kan loggføre besøkendes IP-adresser for sikkerhet og misbruksvern. Vi har ikke tilgang til disse loggene og bruker dem ikke. Se GitHubs personvernerklæring for detaljer.</p>
+        <h2>Hosting</h2>
+        <p>The website is a static site hosted on GitHub Pages. GitHub, as the host, may log visitor IP addresses for security and abuse-prevention purposes. We do not access or use those logs. See the GitHub Privacy Statement for details.</p>
 
-        <h2>E-post</h2>
-        <p>Vi bruker Proton Mail som e-postleverandør. Meldinger i vår innboks lagres med null-tilgangskryptering.</p>
+        <h2>Email</h2>
+        <p>We use Proton Mail as our email provider. Messages in our mailbox are stored with zero-access encryption.</p>
 
-        <h2>Behandlingsgrunnlag</h2>
-        <p>GDPR art. 6(1)(b) (tiltak før avtale) og art. 6(1)(f) (vår berettigede interesse i å besvare henvendelser og føre nødvendige arkiv).</p>
+        <h2>Lawful basis</h2>
+        <p>GDPR Art. 6(1)(b) (to take steps at your request before a contract) and Art. 6(1)(f) (our legitimate interests in responding to enquiries and maintaining records).</p>
 
-        <h2>Lagringstid</h2>
-        <p>Henvendelser lagres inntil 12 måneder og slettes deretter, med mindre lovpålagte krav tilsier lengre lagring. Du kan be om tidligere sletting.</p>
+        <h2>Retention</h2>
+        <p>We keep enquiries for up to 12 months, then delete them unless legal obligations require longer. You can ask us to delete earlier.</p>
 
-        <h2>Dine rettigheter</h2>
-        <p>Du kan be om innsyn, retting, sletting, begrensning, eller protestere. Du kan også klage til Datatilsynet.</p>
+        <h2>Your rights</h2>
+        <p>You can request access, rectification, erasure, restriction, or object to processing, and you may complain to Datatilsynet (the Norwegian Data Protection Authority).</p>
 
-        <h2>Kontakt</h2>
+        <h2>Contact</h2>
         <p><a href="mailto:contact@rdnordic.com">contact@rdnordic.com</a></p>
     </main>
     <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
     </footer>
 </body>
 </html>

--- a/no/services/ai-ethics.html
+++ b/no/services/ai-ethics.html
@@ -1,67 +1,66 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>KI-integrasjon og etikk | R&amp;D Nordic</title>
-    <meta name="description" content="Etiske KI-strategier som balanserer innovasjon med ansvarlighet og åpenhet.">
+    <title>AI Integration &amp; Ethics | R&amp;D Nordic</title>
+    <meta name="description" content="Ethical AI strategies that balance innovation with accountability and transparency.">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="../../style.css">
-      <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/ai-ethics.html">
-      <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/ai-ethics.html">
-      <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/ai-ethics.html">
+    <link rel="stylesheet" href="/style.css">
+    <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/ai-ethics.html">
+    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/ai-ethics.html">
+    <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/ai-ethics.html">
 </head>
 <body>
     <header class="site-header">
         <nav class="navbar container">
-              <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
-              <ul class="nav-links">
-                  <li><a href="../index.html#hero">Hjem</a></li>
-                  <li><a href="../index.html#services">Hva gjør vi</a></li>
-                  <li><a href="../index.html#why-us">Hvorfor velge oss</a></li>
-                  <li><a href="../index.html#cases">Erfaringer</a></li>
-                  <li><a href="../index.html#contact">Kontakt</a></li>
-              </ul>
-              <span class="ml-4 text-sm">
-                  <a href="/services/ai-ethics.html">EN</a>
-                  <span class="mx-1">|</span>
-                  <a href="/no/services/ai-ethics.html" aria-current="page" class="font-semibold">NO</a>
-              </span>
-          </nav>
-      </header>
-      <main class="container py-8">
-        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">KI-integrasjon og etikk</h1>
+            <a class="logo" href="/index.html#hero">R&amp;D Nordic</a>
+            <ul class="nav-links">
+                <li><a href="/index.html#hero">Home</a></li>
+                <li><a href="/index.html#services">What We Do</a></li>
+                <li><a href="/index.html#why-us">Why Us</a></li>
+                <li><a href="/index.html#cases">Cases</a></li>
+                <li><a href="/index.html#contact">Contact</a></li>
+            </ul>
+            <span class="ml-4 text-sm">
+                <a href="/services/ai-ethics.html">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/services/ai-ethics.html" aria-current="page" class="font-semibold">NO</a>
+            </span>
+        </nav>
+    </header>
+    <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">AI Integration &amp; Ethics</h1>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Utfordringen vi løser</h2>
-            <p class="text-gray-700">Organisasjoner ønsker produktiviteten fra KI, men frykter skjevhet, manglende åpenhet og regulatorisk usikkerhet.</p>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
+            <p class="text-gray-700">Organisations want the productivity of AI but fear bias, opacity and regulatory uncertainty.</p>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Vår tilnærming</h2>
-            <p class="text-gray-700">Vi vurderer brukstilfeller, analyserer konsekvenser og bygger styring slik at automatisering forblir transparent og rettferdig.</p>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Our approach</h2>
+            <p class="text-gray-700">We evaluate use cases, assess impacts and embed governance so automation remains transparent and fair.</p>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typiske leveranser</h2>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typical deliverables</h2>
             <ul class="list-disc pl-5 text-gray-700 space-y-1">
-                <li>Workshops om KI-beredskap og risiko</li>
-                <li>Etiske retningslinjer og styringsrammeverk</li>
-                <li>Vurderinger av skjevhet og transparens</li>
-                <li>Støtte til prototyper eller integrasjon</li>
+                <li>AI readiness and risk workshops</li>
+                <li>Ethical guidelines and governance frameworks</li>
+                <li>Bias and transparency assessments</li>
+                <li>Prototype or integration support</li>
             </ul>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Resultater</h2>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Outcomes</h2>
             <ul class="list-disc pl-5 text-gray-700 space-y-1">
-                <li>Ansvarlige, forklarbare KI-løsninger</li>
-                <li>Redusert etisk og regulatorisk risiko</li>
-                <li>Tillit hos interessenter og myndigheter</li>
+                <li>Responsible, explainable AI solutions</li>
+                <li>Reduced ethical and compliance risk</li>
+                <li>Confidence from stakeholders and regulators</li>
             </ul>
         </section>
-        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book et møte</a>
-      </main>
-      <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
-      </footer>
-    </body>
-    </html>
-
+        <a href="/index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
+    </footer>
+</body>
+</html>

--- a/no/services/grant-funding.html
+++ b/no/services/grant-funding.html
@@ -1,67 +1,66 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Forskningsmidler | R&amp;D Nordic</title>
-    <meta name="description" content="Ekspertstøtte til å finne utlysninger, utvikle søknader og sikre forskningsmidler.">
+    <title>Grant Funding | R&amp;D Nordic</title>
+    <meta name="description" content="Expert support to find calls, craft proposals and secure research funding.">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="../../style.css">
-      <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/grant-funding.html">
-      <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/grant-funding.html">
-      <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/grant-funding.html">
+    <link rel="stylesheet" href="/style.css">
+    <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/grant-funding.html">
+    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/grant-funding.html">
+    <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/grant-funding.html">
 </head>
 <body>
     <header class="site-header">
         <nav class="navbar container">
-              <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
-              <ul class="nav-links">
-                  <li><a href="../index.html#hero">Hjem</a></li>
-                  <li><a href="../index.html#services">Hva gjør vi</a></li>
-                  <li><a href="../index.html#why-us">Hvorfor velge oss</a></li>
-                  <li><a href="../index.html#cases">Erfaringer</a></li>
-                  <li><a href="../index.html#contact">Kontakt</a></li>
-              </ul>
-              <span class="ml-4 text-sm">
-                  <a href="/services/grant-funding.html">EN</a>
-                  <span class="mx-1">|</span>
-                  <a href="/no/services/grant-funding.html" aria-current="page" class="font-semibold">NO</a>
-              </span>
-          </nav>
-      </header>
-      <main class="container py-8">
-        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Forskningsmidler</h1>
+            <a class="logo" href="/index.html#hero">R&amp;D Nordic</a>
+            <ul class="nav-links">
+                <li><a href="/index.html#hero">Home</a></li>
+                <li><a href="/index.html#services">What We Do</a></li>
+                <li><a href="/index.html#why-us">Why Us</a></li>
+                <li><a href="/index.html#cases">Cases</a></li>
+                <li><a href="/index.html#contact">Contact</a></li>
+            </ul>
+            <span class="ml-4 text-sm">
+                <a href="/services/grant-funding.html">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/services/grant-funding.html" aria-current="page" class="font-semibold">NO</a>
+            </span>
+        </nav>
+    </header>
+    <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Grant Funding</h1>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Utfordringen vi løser</h2>
-            <p class="text-gray-700">Å finne riktig program og utarbeide en konkurransedyktig søknad er tidkrevende og komplekst.</p>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
+            <p class="text-gray-700">Identifying the right programme and preparing a competitive proposal is time consuming and complex.</p>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Vår tilnærming</h2>
-            <p class="text-gray-700">Vi søker etter utlysninger, former konsepter og veileder innsendingen for å møte forventningene til finansieringsgiver.</p>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Our approach</h2>
+            <p class="text-gray-700">We scan calls, shape concepts and guide submissions to match funder expectations.</p>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typiske leveranser</h2>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typical deliverables</h2>
             <ul class="list-disc pl-5 text-gray-700 space-y-1">
-                <li>Søk i finansieringsmuligheter</li>
-                <li>Konseptnotater og utkast til søknader</li>
-                <li>Budsjett- og effektbeskrivelser</li>
-                <li>Håndtering av innsending</li>
+                <li>Funding opportunity scans</li>
+                <li>Concept notes and proposal drafts</li>
+                <li>Budget and impact narratives</li>
+                <li>Submission management</li>
             </ul>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Resultater</h2>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Outcomes</h2>
             <ul class="list-disc pl-5 text-gray-700 space-y-1">
-                <li>Høyere tilslagsrate</li>
-                <li>Klare prosjektplaner i tråd med krav</li>
-                <li>Ressurser sikret for å drive innovasjon</li>
+                <li>Higher win rates for grants</li>
+                <li>Clear, funder-aligned project plans</li>
+                <li>Resources secured to advance innovation</li>
             </ul>
         </section>
-        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book et møte</a>
-      </main>
-      <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
-      </footer>
-    </body>
-    </html>
-
+        <a href="/index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
+    </footer>
+</body>
+</html>

--- a/no/services/privacy-gdpr.html
+++ b/no/services/privacy-gdpr.html
@@ -1,67 +1,66 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Personvern og GDPR | R&amp;D Nordic</title>
-    <meta name="description" content="Praktisk GDPR-veiledning for å kartlegge data, redusere risiko og bygge tillitsfulle prosesser.">
+    <title>Privacy &amp; GDPR | R&amp;D Nordic</title>
+    <meta name="description" content="Hands-on GDPR guidance to map data, mitigate risk and build trusted processes.">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="../../style.css">
-      <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/privacy-gdpr.html">
-      <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/privacy-gdpr.html">
-      <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/privacy-gdpr.html">
+    <link rel="stylesheet" href="/style.css">
+    <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/privacy-gdpr.html">
+    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/privacy-gdpr.html">
+    <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/privacy-gdpr.html">
 </head>
 <body>
     <header class="site-header">
         <nav class="navbar container">
-              <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
-              <ul class="nav-links">
-                  <li><a href="../index.html#hero">Hjem</a></li>
-                  <li><a href="../index.html#services">Hva gjør vi</a></li>
-                  <li><a href="../index.html#why-us">Hvorfor velge oss</a></li>
-                  <li><a href="../index.html#cases">Erfaringer</a></li>
-                  <li><a href="../index.html#contact">Kontakt</a></li>
-              </ul>
-              <span class="ml-4 text-sm">
-                  <a href="/services/privacy-gdpr.html">EN</a>
-                  <span class="mx-1">|</span>
-                  <a href="/no/services/privacy-gdpr.html" aria-current="page" class="font-semibold">NO</a>
-              </span>
-          </nav>
-      </header>
-      <main class="container py-8">
-        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Personvern og GDPR</h1>
+            <a class="logo" href="/index.html#hero">R&amp;D Nordic</a>
+            <ul class="nav-links">
+                <li><a href="/index.html#hero">Home</a></li>
+                <li><a href="/index.html#services">What We Do</a></li>
+                <li><a href="/index.html#why-us">Why Us</a></li>
+                <li><a href="/index.html#cases">Cases</a></li>
+                <li><a href="/index.html#contact">Contact</a></li>
+            </ul>
+            <span class="ml-4 text-sm">
+                <a href="/services/privacy-gdpr.html">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/services/privacy-gdpr.html" aria-current="page" class="font-semibold">NO</a>
+            </span>
+        </nav>
+    </header>
+    <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Privacy &amp; GDPR</h1>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Utfordringen vi løser</h2>
-            <p class="text-gray-700">Mange organisasjoner samler inn personopplysninger uten full oversikt, noe som skaper mangler i etterlevelsen og risiko for gebyrer.</p>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
+            <p class="text-gray-700">Many organisations collect personal data without clear oversight, creating compliance gaps and exposure to fines.</p>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Vår tilnærming</h2>
-            <p class="text-gray-700">Vi kartlegger dataflyt, vurderer risiko og etablerer styring slik at personvernforpliktelser oppfylles.</p>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Our approach</h2>
+            <p class="text-gray-700">We map data flows, assess risks and implement governance so privacy obligations are met across the board.</p>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typiske leveranser</h2>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typical deliverables</h2>
             <ul class="list-disc pl-5 text-gray-700 space-y-1">
-                <li>Oversikter over behandlingsaktiviteter</li>
-                <li>Personvernkonsekvensvurderinger</li>
-                <li>Personvernerklæringer og samtykketekster</li>
-                <li>Opplæring og bevisstgjøring for ansatte</li>
+                <li>Data processing inventories</li>
+                <li>Data protection impact assessments</li>
+                <li>Privacy policies and consent language</li>
+                <li>Staff training and awareness sessions</li>
             </ul>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Resultater</h2>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Outcomes</h2>
             <ul class="list-disc pl-5 text-gray-700 space-y-1">
-                <li>Redusert risiko for brudd og bøter</li>
-                <li>Dokumentert etterlevelse av regelverk</li>
-                <li>Økt tillit fra kunder og partnere</li>
+                <li>Reduced breach and penalty risk</li>
+                <li>Demonstrated regulatory compliance</li>
+                <li>Greater trust from customers and partners</li>
             </ul>
         </section>
-        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book et møte</a>
-      </main>
-      <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
-      </footer>
-    </body>
-    </html>
-
+        <a href="/index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
+    </footer>
+</body>
+</html>

--- a/no/services/project-management.html
+++ b/no/services/project-management.html
@@ -1,67 +1,66 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Prosjektledelse | R&amp;D Nordic</title>
-    <meta name="description" content="Strukturert prosjektledelse som holder milepæler, risiko og team på sporet.">
+    <title>Project Management | R&amp;D Nordic</title>
+    <meta name="description" content="Structured project leadership that keeps milestones, risks and teams on track.">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="../../style.css">
-      <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/project-management.html">
-      <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/project-management.html">
-      <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/project-management.html">
+    <link rel="stylesheet" href="/style.css">
+    <link rel="alternate" hreflang="en" href="https://rdnordic.com/services/project-management.html">
+    <link rel="alternate" hreflang="no" href="https://rdnordic.com/no/services/project-management.html">
+    <link rel="alternate" hreflang="x-default" href="https://rdnordic.com/services/project-management.html">
 </head>
 <body>
     <header class="site-header">
         <nav class="navbar container">
-              <a class="logo" href="../index.html#hero">R&amp;D Nordic</a>
-              <ul class="nav-links">
-                  <li><a href="../index.html#hero">Hjem</a></li>
-                  <li><a href="../index.html#services">Hva gjør vi</a></li>
-                  <li><a href="../index.html#why-us">Hvorfor velge oss</a></li>
-                  <li><a href="../index.html#cases">Erfaringer</a></li>
-                  <li><a href="../index.html#contact">Kontakt</a></li>
-              </ul>
-              <span class="ml-4 text-sm">
-                  <a href="/services/project-management.html">EN</a>
-                  <span class="mx-1">|</span>
-                  <a href="/no/services/project-management.html" aria-current="page" class="font-semibold">NO</a>
-              </span>
-          </nav>
-      </header>
-      <main class="container py-8">
-        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Prosjektledelse</h1>
+            <a class="logo" href="/index.html#hero">R&amp;D Nordic</a>
+            <ul class="nav-links">
+                <li><a href="/index.html#hero">Home</a></li>
+                <li><a href="/index.html#services">What We Do</a></li>
+                <li><a href="/index.html#why-us">Why Us</a></li>
+                <li><a href="/index.html#cases">Cases</a></li>
+                <li><a href="/index.html#contact">Contact</a></li>
+            </ul>
+            <span class="ml-4 text-sm">
+                <a href="/services/project-management.html">EN</a>
+                <span class="mx-1">|</span>
+                <a href="/no/services/project-management.html" aria-current="page" class="font-semibold">NO</a>
+            </span>
+        </nav>
+    </header>
+    <main class="container py-8">
+        <h1 class="text-3xl font-semibold text-[#005b96] mb-6">Project Management</h1>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Utfordringen vi løser</h2>
-            <p class="text-gray-700">Team sliter med skiftende prioriteringer, begrensede ressurser og uklare roller som forsinker tidsplaner.</p>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Problem we solve</h2>
+            <p class="text-gray-700">Teams struggle with shifting priorities, limited resources and unclear roles that derail timelines.</p>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Vår tilnærming</h2>
-            <p class="text-gray-700">Vi kombinerer strukturert planlegging med smidige rutiner for å skape klarhet, håndtere risiko og holde interessenter samkjørt.</p>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Our approach</h2>
+            <p class="text-gray-700">We blend structured planning with agile routines to establish clarity, manage risks and keep stakeholders aligned.</p>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typiske leveranser</h2>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Typical deliverables</h2>
             <ul class="list-disc pl-5 text-gray-700 space-y-1">
-                <li>Prosjektmandater og veikart</li>
-                <li>Sprintplaner og oppgavetavler</li>
-                <li>Risiko- og avviksregistre</li>
-                <li>Kommunikasjonsplaner for interessenter</li>
+                <li>Project charters and roadmaps</li>
+                <li>Sprint schedules and task boards</li>
+                <li>Risk and issue registers</li>
+                <li>Stakeholder communication plans</li>
             </ul>
         </section>
         <section class="mb-6">
-            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Resultater</h2>
+            <h2 class="text-2xl font-semibold text-[#005b96] mb-4">Outcomes</h2>
             <ul class="list-disc pl-5 text-gray-700 space-y-1">
-                <li>Klare milepæler og ansvar</li>
-                <li>Kontrollerte risikoer og omfang</li>
-                <li>Prosjekter levert i tide</li>
+                <li>Clear milestones and ownership</li>
+                <li>Controlled risks and scope</li>
+                <li>Projects delivered on time</li>
             </ul>
         </section>
-        <a href="../index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book et møte</a>
-      </main>
-      <footer class="site-footer">
-        <p>&copy; 2025 R&amp;D Nordic. Alle rettigheter forbeholdt. <a href="/no/privacy.html">Personvern</a> | <a href="/no/index.html#contact">Kontakt</a></p>
-      </footer>
-    </body>
-    </html>
-
+        <a href="/index.html#contact" class="inline-block mt-4 px-6 py-3 bg-[#005b96] text-white font-semibold rounded">Book a meeting</a>
+    </main>
+    <footer class="site-footer">
+        <p>&copy; 2025 R&amp;D Nordic. All rights reserved. <a href="/privacy.html">Privacy Notice</a> | <a href="/index.html#contact">Contact</a></p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the Norwegian landing page with the current English copy, including navigation labels and section text
- update the Norwegian privacy notice and service detail pages to match their English counterparts while keeping NO as the active locale toggle

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68eb76dfb39c83238741b0d78d6f7b25